### PR TITLE
Refactor logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
 
 [project]
 name = "cloud-autopkg-runner"
-version = "0.9.9"
+version = "0.10.0"
 description = "A Python library designed to level-up your AutoPkg automations with a focus on CI/CD performance."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/cloud_autopkg_runner/__init__.py
+++ b/src/cloud_autopkg_runner/__init__.py
@@ -14,7 +14,6 @@ Key features include:
 """
 
 import logging
-import sys
 from pathlib import Path
 
 # Create a logger instance
@@ -25,8 +24,7 @@ class AppConfig:
     """Manages application-wide configuration settings.
 
     This class uses class variables to store configuration data and
-    class methods to manage and access that data. It handles
-    the initialization of the logging system and provides access
+    class methods to manage and access that data. It provides access
     to configuration parameters such as verbosity level, log file path,
     and the metadata cache file path.
     """
@@ -76,43 +74,6 @@ class AppConfig:
 
         if report_dir is not None:
             cls._report_dir = report_dir
-
-    @classmethod
-    def initialize_logger(cls) -> None:
-        """Initialize the logging system.
-
-        Configures the root logger with a console handler and an optional
-        file handler. The console handler's log level is determined by the
-        current verbosity level, while the file handler (if enabled) logs at
-        the DEBUG level. The logging is initialized using values in the class.
-
-        The logging formatters include the module name, log level, and message,
-        with the file handler also including a timestamp.
-        """
-        log_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
-        level = log_levels[min(cls._verbosity_level, len(log_levels) - 1)]
-
-        logger.setLevel(logging.DEBUG)
-
-        # Console handler
-        console_handler = logging.StreamHandler(sys.stdout)
-        console_handler.setLevel(level)
-        console_formatter = logging.Formatter(
-            "%(module)-20s %(levelname)-8s %(message)s"
-        )
-        console_handler.setFormatter(console_formatter)
-        logger.addHandler(console_handler)
-
-        # File handler (optional)
-        if cls._log_file:
-            file_handler = logging.FileHandler(cls._log_file, mode="w")
-            file_handler.setLevel(logging.DEBUG)
-            file_formatter = logging.Formatter(
-                "%(asctime)s %(module)-20s %(levelname)-8s %(message)s",
-                datefmt="%m-%d %H:%M",
-            )
-            file_handler.setFormatter(file_formatter)
-            logger.addHandler(file_handler)
 
     @classmethod
     def cache_file(cls) -> Path:

--- a/src/cloud_autopkg_runner/__init__.py
+++ b/src/cloud_autopkg_runner/__init__.py
@@ -13,11 +13,7 @@ Key features include:
 - Metadata caching to reduce redundant downloads.
 """
 
-import logging
 from pathlib import Path
-
-# Create a logger instance
-logger: logging.Logger = logging.getLogger(__name__)
 
 
 class AppConfig:

--- a/src/cloud_autopkg_runner/__main__.py
+++ b/src/cloud_autopkg_runner/__main__.py
@@ -24,14 +24,14 @@ from pathlib import Path
 from types import FrameType
 from typing import NoReturn
 
-from cloud_autopkg_runner import AppConfig, logger
+from cloud_autopkg_runner import AppConfig
 from cloud_autopkg_runner.exceptions import (
     InvalidFileContents,
     InvalidJsonContents,
     RecipeException,
 )
 from cloud_autopkg_runner.file_utils import create_dummy_files
-from cloud_autopkg_runner.logging_config import initialize_logger
+from cloud_autopkg_runner.logging_config import get_logger, initialize_logger
 from cloud_autopkg_runner.metadata_cache import MetadataCacheManager
 from cloud_autopkg_runner.recipe import ConsolidatedReport, Recipe
 
@@ -54,6 +54,7 @@ def _generate_recipe_list(args: Namespace) -> set[str]:
         InvalidJsonContents: If the JSON file specified by 'args.recipe_list' contains
             invalid JSON.
     """
+    logger = get_logger(__name__)
     logger.debug("Generating recipe list...")
 
     output: set[str] = set()
@@ -148,6 +149,7 @@ async def _process_recipe_list(
     Args:
         recipe_list: An iterable of recipe names (strings).
     """
+    logger = get_logger(__name__)
     logger.debug("Processing recipes...")
 
     report_dir = AppConfig.report_dir()
@@ -178,6 +180,7 @@ def _signal_handler(sig: int, _frame: FrameType | None) -> NoReturn:
         sig: The signal number (an integer).
         _frame:  Unused frame object. Required by signal.signal().
     """
+    logger = get_logger(__name__)
     logger.error(f"Signal {sig} received. Exiting...")
     sys.exit(0)  # Trigger a normal exit
 

--- a/src/cloud_autopkg_runner/__main__.py
+++ b/src/cloud_autopkg_runner/__main__.py
@@ -31,6 +31,7 @@ from cloud_autopkg_runner.exceptions import (
     RecipeException,
 )
 from cloud_autopkg_runner.file_utils import create_dummy_files
+from cloud_autopkg_runner.logging_config import initialize_logger
 from cloud_autopkg_runner.metadata_cache import MetadataCacheManager
 from cloud_autopkg_runner.recipe import ConsolidatedReport, Recipe
 
@@ -196,6 +197,7 @@ async def _async_main() -> None:
       running each recipe asynchronously.
     """
     args = _parse_arguments()
+    initialize_logger(args.verbose, args.log_file)
 
     AppConfig.set_config(
         cache_file=args.cache_file,
@@ -204,7 +206,6 @@ async def _async_main() -> None:
         report_dir=args.report_dir,
         verbosity_level=args.verbose,
     )
-    AppConfig.initialize_logger()
 
     recipe_list = _generate_recipe_list(args)
 

--- a/src/cloud_autopkg_runner/__main__.py
+++ b/src/cloud_autopkg_runner/__main__.py
@@ -71,7 +71,7 @@ def _generate_recipe_list(args: Namespace) -> set[str]:
     if os.getenv("RECIPE"):
         output.add(os.getenv("RECIPE", ""))
 
-    logger.debug(f"Recipe list generated: {output}")
+    logger.debug("Recipe list generated: %s", output)
     return output
 
 
@@ -181,7 +181,7 @@ def _signal_handler(sig: int, _frame: FrameType | None) -> NoReturn:
         _frame:  Unused frame object. Required by signal.signal().
     """
     logger = get_logger(__name__)
-    logger.error(f"Signal {sig} received. Exiting...")
+    logger.error("Signal %s received. Exiting...", sig)
     sys.exit(0)  # Trigger a normal exit
 
 

--- a/src/cloud_autopkg_runner/file_utils.py
+++ b/src/cloud_autopkg_runner/file_utils.py
@@ -73,24 +73,24 @@ async def create_dummy_files(recipe_list: Iterable[str], cache: MetadataCache) -
         if recipe_name not in possible_names:
             continue
 
-        logger.info(f"Creating dummy files for {recipe_name}...")
+        logger.info("Creating dummy files for %s...", recipe_name)
         for metadata_cache in recipe_cache_data.get("metadata", []):
             if not metadata_cache.get("file_path"):
                 logger.warning(
-                    "Skipping file creation: "
-                    f"Missing 'file_path' in {recipe_name} cache"
+                    "Skipping file creation: Missing 'file_path' in %s cache",
+                    recipe_name,
                 )
                 continue
             if not metadata_cache.get("file_size"):
                 logger.warning(
-                    "Skipping file creation: "
-                    f"Missing 'file_size' in {recipe_name} cache"
+                    "Skipping file creation: Missing 'file_size' in %s cache",
+                    recipe_name,
                 )
                 continue
 
             file_path = Path(metadata_cache.get("file_path", ""))
             if file_path.exists():
-                logger.info(f"Skipping file creation: {file_path} already exists.")
+                logger.info("Skipping file creation: %s already exists.", file_path)
                 continue
 
             # Add the task to create the file, set its size, and set extended attributes

--- a/src/cloud_autopkg_runner/file_utils.py
+++ b/src/cloud_autopkg_runner/file_utils.py
@@ -22,7 +22,8 @@ from typing import cast
 
 import xattr  # pyright: ignore[reportMissingTypeStubs]
 
-from cloud_autopkg_runner import list_possible_file_names, logger
+from cloud_autopkg_runner import list_possible_file_names
+from cloud_autopkg_runner.logging_config import get_logger
 from cloud_autopkg_runner.metadata_cache import DownloadMetadata, MetadataCache
 
 
@@ -59,6 +60,7 @@ async def create_dummy_files(recipe_list: Iterable[str], cache: MetadataCache) -
         recipe_list: An iterable of recipe names to process.
         cache: The metadata cache dictionary.
     """
+    logger = get_logger(__name__)
     logger.debug("Creating dummy files...")
 
     tasks: list[asyncio.Task[None]] = []

--- a/src/cloud_autopkg_runner/logging_config.py
+++ b/src/cloud_autopkg_runner/logging_config.py
@@ -1,0 +1,75 @@
+"""Module for initializing and managing logging within cloud-autopkg-runner.
+
+This module provides functions for configuring the logging system,
+allowing for flexible control over the verbosity level and output
+destinations (console and/or file). It also offers a convenient way to
+retrieve logger instances for use in other modules.
+
+Functions:
+    initialize_logger: Initializes the logging system with a console handler
+        and an optional file handler.
+    get_logger: Retrieves a logger instance with the specified name.
+"""
+
+import logging
+import sys
+from typing import TextIO
+
+
+def initialize_logger(verbosity_level: int, log_file: str | None = None) -> None:
+    """Initializes the logging system.
+
+    Configures the root logger with a console handler and an optional file
+    handler. The console handler's log level is determined by the
+    `verbosity_level` argument, while the file handler (if enabled) logs at
+    the DEBUG level.
+
+    Args:
+        verbosity_level: An integer representing the verbosity level.  Maps to
+            logging levels as follows:
+            0: WARNING, 1: INFO, 2: DEBUG (and higher).
+        log_file: Optional path to a log file. If specified, logging output
+            will be written to this file in addition to the console. If None,
+            no file logging will occur.
+    """
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+
+    log_levels: list[int] = [logging.WARNING, logging.INFO, logging.DEBUG]
+    level: int = log_levels[min(verbosity_level, len(log_levels) - 1)]
+
+    # Console handler
+    console_handler: logging.StreamHandler[TextIO] = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(level)
+    console_formatter: logging.Formatter = logging.Formatter(
+        "%(module)-20s %(levelname)-8s %(message)s"
+    )
+    console_handler.setFormatter(console_formatter)
+    logger.addHandler(console_handler)
+
+    # File handler (optional)
+    if log_file:
+        file_handler: logging.FileHandler = logging.FileHandler(log_file, mode="w")
+        file_handler.setLevel(logging.DEBUG)
+        file_formatter: logging.Formatter = logging.Formatter(
+            "%(asctime)s %(module)-20s %(levelname)-8s %(message)s",
+            datefmt="%m-%d %H:%M",
+        )
+        file_handler.setFormatter(file_formatter)
+        logger.addHandler(file_handler)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Get a logger instance.
+
+    Retrieves a logger instance with the specified name. This function
+    simplifies the process of obtaining loggers for use in different
+    modules of the application.
+
+    Args:
+        name: The name of the logger to retrieve (typically `__name__`).
+
+    Returns:
+        A Logger instance with the specified name.
+    """
+    return logging.getLogger(name)

--- a/src/cloud_autopkg_runner/logging_config.py
+++ b/src/cloud_autopkg_runner/logging_config.py
@@ -27,7 +27,7 @@ def initialize_logger(verbosity_level: int, log_file: str | None = None) -> None
     Args:
         verbosity_level: An integer representing the verbosity level.  Maps to
             logging levels as follows:
-            0: WARNING, 1: INFO, 2: DEBUG (and higher).
+            0: ERROR, 1: WARNING, 2: INFO, 3: DEBUG (and higher).
         log_file: Optional path to a log file. If specified, logging output
             will be written to this file in addition to the console. If None,
             no file logging will occur.
@@ -35,7 +35,14 @@ def initialize_logger(verbosity_level: int, log_file: str | None = None) -> None
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
 
-    log_levels: list[int] = [logging.WARNING, logging.INFO, logging.DEBUG]
+    logger.handlers.clear()
+
+    log_levels: list[int] = [
+        logging.ERROR,
+        logging.WARNING,
+        logging.INFO,
+        logging.DEBUG,
+    ]
     level: int = log_levels[min(verbosity_level, len(log_levels) - 1)]
 
     # Console handler

--- a/src/cloud_autopkg_runner/metadata_cache.py
+++ b/src/cloud_autopkg_runner/metadata_cache.py
@@ -16,8 +16,8 @@ import json
 from pathlib import Path
 from typing import TypeAlias, TypedDict
 
-from cloud_autopkg_runner import logger
 from cloud_autopkg_runner.exceptions import InvalidJsonContents
+from cloud_autopkg_runner.logging_config import get_logger
 
 
 class DownloadMetadata(TypedDict, total=False):
@@ -88,6 +88,7 @@ class MetadataCacheManager:
         """
         async with cls._lock:
             if cls._cache is None:
+                logger = get_logger(__name__)
                 logger.debug("Loading metadata cache for the first time...")
                 cls._cache = await asyncio.to_thread(cls._load_from_disk, file_path)
             return cls._cache
@@ -132,6 +133,7 @@ class MetadataCacheManager:
             InvalidJsonContents: If the JSON contents of the file are invalid.
         """
         if not file_path.exists():
+            logger = get_logger(__name__)
             logger.warning(f"{file_path} does not exist. Creating...")
             file_path.write_text("{}")
             logger.info(f"{file_path} created.")
@@ -152,5 +154,6 @@ class MetadataCacheManager:
             file_path: The path to the file where the metadata cache is stored.
             metadata_cache: The metadata cache to be saved.
         """
+        logger = get_logger(__name__)
         file_path.write_text(json.dumps(metadata_cache, indent=2, sort_keys=True))
         logger.info(f"Metadata cache saved to {file_path}.")

--- a/src/cloud_autopkg_runner/metadata_cache.py
+++ b/src/cloud_autopkg_runner/metadata_cache.py
@@ -134,9 +134,9 @@ class MetadataCacheManager:
         """
         if not file_path.exists():
             logger = get_logger(__name__)
-            logger.warning(f"{file_path} does not exist. Creating...")
+            logger.warning("%s does not exist. Creating...", file_path)
             file_path.write_text("{}")
-            logger.info(f"{file_path} created.")
+            logger.info("%s created.", file_path)
 
         try:
             return MetadataCache(json.loads(file_path.read_text()))
@@ -156,4 +156,4 @@ class MetadataCacheManager:
         """
         logger = get_logger(__name__)
         file_path.write_text(json.dumps(metadata_cache, indent=2, sort_keys=True))
-        logger.info(f"Metadata cache saved to {file_path}.")
+        logger.info("Metadata cache saved to %s.", file_path)

--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -108,9 +108,9 @@ class Recipe:
 
         try:
             self._path: Path = self.find_recipe(recipe_name)
-        except RecipeLookupException as exc:
+        except RecipeLookupException:
             logger = get_logger(__name__)
-            logger.error(exc)
+            logger.exception("Failed to find recipe: %s", recipe_name)
             raise
 
         self._format: RecipeFormat = self.format()
@@ -476,7 +476,7 @@ class Recipe:
             A ConsolidatedReport object containing the results of the check phase.
         """
         logger = get_logger(__name__)
-        logger.debug(f"Performing Check Phase on {self.name}...")
+        logger.debug("Performing Check Phase on %s...", self.name)
 
         returncode, _stdout, stderr = await run_cmd(
             self._autopkg_run_cmd(check=True), check=False
@@ -486,8 +486,9 @@ class Recipe:
             if not stderr:
                 stderr = "<Unknown Error>"
             logger.error(
-                f"An error occurred while running the check phase, "
-                f"on {self.name}: {stderr}"
+                "An error occurred while running the check phase, on %s: %s",
+                self.name,
+                stderr,
             )
 
         return self.compile_report()
@@ -505,7 +506,7 @@ class Recipe:
             A ConsolidatedReport object containing the results of the full recipe run.
         """
         logger = get_logger(__name__)
-        logger.debug(f"Performing AutoPkg Run on {self.name}...")
+        logger.debug("Performing AutoPkg Run on %s...", self.name)
 
         returncode, _stdout, stderr = await run_cmd(
             self._autopkg_run_cmd(check=False), check=False
@@ -514,7 +515,7 @@ class Recipe:
         if returncode != 0:
             if not stderr:
                 stderr = "<Unknown Error>"
-            logger.error(f"An error occurred while running {self.name}: {stderr}")
+            logger.error("An error occurred while running %s: %s", self.name, stderr)
 
         return self.compile_report()
 
@@ -527,7 +528,7 @@ class Recipe:
             True if the trust info was successfully updated, False otherwise.
         """
         logger = get_logger(__name__)
-        logger.debug(f"Updating trust info for {self.name}...")
+        logger.debug("Updating trust info for %s...", self.name)
 
         cmd = [
             "/usr/local/bin/autopkg",
@@ -542,10 +543,10 @@ class Recipe:
         self._trusted = TrustInfoVerificationState.UNTESTED
 
         if returncode == 0:
-            logger.info(f"Trust info update for {self.name} successful.")
+            logger.info("Trust info update for %s successful.", self.name)
             return True
 
-        logger.warning(f"Trust info update for {self.name} failed.")
+        logger.warning("Trust info update for %s failed.", self.name)
         return False
 
     async def verify_trust_info(self) -> bool:
@@ -557,9 +558,10 @@ class Recipe:
             TrustInfoVerificationState.TRUSTED if the trust info is trusted,
             TrustInfoVerificationState.FAILED if it is untrusted, or
         """
+        logger = get_logger(__name__)
 
         if self._trusted == TrustInfoVerificationState.UNTESTED:
-            logger.debug(f"Verifying trust info for {self.name}...")
+            logger.debug("Verifying trust info for %s...", self.name)
 
             cmd = [
                 "/usr/local/bin/autopkg",
@@ -574,10 +576,10 @@ class Recipe:
             returncode, _stdout, _stderr = await run_cmd(cmd, check=False)
 
             if returncode == 0:
-                logger.info(f"Trust info verification for {self.name} successful.")
+                logger.info("Trust info verification for %s successful.", self.name)
                 self._trusted = TrustInfoVerificationState.TRUSTED
             else:
-                logger.warning(f"Trust info verification for {self.name} failed.")
+                logger.warning("Trust info verification for %s failed.", self.name)
                 self._trusted = TrustInfoVerificationState.FAILED
 
         return self._trusted.value

--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -21,7 +21,7 @@ from typing import Any, TypedDict
 
 import yaml
 
-from cloud_autopkg_runner import AppConfig, logger
+from cloud_autopkg_runner import AppConfig
 from cloud_autopkg_runner.autopkg_prefs import AutoPkgPrefs
 from cloud_autopkg_runner.exceptions import (
     InvalidPlistContents,
@@ -31,6 +31,7 @@ from cloud_autopkg_runner.exceptions import (
     RecipeLookupException,
 )
 from cloud_autopkg_runner.file_utils import get_file_metadata, get_file_size
+from cloud_autopkg_runner.logging_config import get_logger
 from cloud_autopkg_runner.metadata_cache import (
     DownloadMetadata,
     MetadataCacheManager,
@@ -108,6 +109,7 @@ class Recipe:
         try:
             self._path: Path = self.find_recipe(recipe_name)
         except RecipeLookupException as exc:
+            logger = get_logger(__name__)
             logger.error(exc)
             raise
 
@@ -473,6 +475,7 @@ class Recipe:
         Returns:
             A ConsolidatedReport object containing the results of the check phase.
         """
+        logger = get_logger(__name__)
         logger.debug(f"Performing Check Phase on {self.name}...")
 
         returncode, _stdout, stderr = await run_cmd(
@@ -501,6 +504,7 @@ class Recipe:
         Returns:
             A ConsolidatedReport object containing the results of the full recipe run.
         """
+        logger = get_logger(__name__)
         logger.debug(f"Performing AutoPkg Run on {self.name}...")
 
         returncode, _stdout, stderr = await run_cmd(
@@ -522,6 +526,7 @@ class Recipe:
         Returns:
             True if the trust info was successfully updated, False otherwise.
         """
+        logger = get_logger(__name__)
         logger.debug(f"Updating trust info for {self.name}...")
 
         cmd = [
@@ -552,6 +557,7 @@ class Recipe:
             TrustInfoVerificationState.TRUSTED if the trust info is trusted,
             TrustInfoVerificationState.FAILED if it is untrusted, or
         """
+
         if self._trusted == TrustInfoVerificationState.UNTESTED:
             logger.debug(f"Verifying trust info for {self.name}...")
 

--- a/src/cloud_autopkg_runner/recipe_report.py
+++ b/src/cloud_autopkg_runner/recipe_report.py
@@ -4,8 +4,8 @@ import plistlib
 from pathlib import Path
 from typing import Any, TypedDict
 
-from cloud_autopkg_runner import logger
 from cloud_autopkg_runner.exceptions import InvalidPlistContents
+from cloud_autopkg_runner.logging_config import get_logger
 
 
 class RecipeReportFailedItem(TypedDict):
@@ -169,6 +169,7 @@ class RecipeReport:
             A ConsolidatedReport dictionary containing the files downloaded, packages
             built, any failures, and Munki imports.
         """
+        logger = get_logger(__name__)
         logger.debug(f"Parsing the report at {self.file_path()}...")
 
         if not self._parsed:

--- a/src/cloud_autopkg_runner/recipe_report.py
+++ b/src/cloud_autopkg_runner/recipe_report.py
@@ -170,7 +170,7 @@ class RecipeReport:
             built, any failures, and Munki imports.
         """
         logger = get_logger(__name__)
-        logger.debug(f"Parsing the report at {self.file_path()}...")
+        logger.debug("Parsing the report at %s...", self.file_path())
 
         if not self._parsed:
             logger.info("Reading the contents of the report...")

--- a/src/cloud_autopkg_runner/shell.py
+++ b/src/cloud_autopkg_runner/shell.py
@@ -78,10 +78,10 @@ async def _run_and_capture(
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
 
-        logger.debug(f"Command output:\n{stdout}\n{stderr}")
+        logger.debug("Command output:\n%s\n%s", stdout, stderr)
 
     except (asyncio.TimeoutError, TimeoutError):
-        logger.warning(f"Command timed out: {' '.join(cmd)}")
+        logger.warning("Command timed out: %s", " ".join(cmd))
         if proc.returncode is None:  # Process still running
             with contextlib.suppress(ProcessLookupError):
                 proc.kill()
@@ -123,7 +123,7 @@ async def _run_without_capture(
     try:
         await asyncio.wait_for(proc.wait(), timeout=timeout)
     except (asyncio.TimeoutError, TimeoutError):
-        logger.warning(f"Command timed out: {' '.join(cmd)}")
+        logger.warning("Command timed out: %s", " ".join(cmd))
         if proc.returncode is None:  # Process still running
             with contextlib.suppress(ProcessLookupError):
                 proc.kill()
@@ -189,9 +189,9 @@ async def run_cmd(
     cmd_list = _normalize_cmd(cmd)
     cmd_str = " ".join(cmd_list)
 
-    logger.debug(f"Running command: {cmd_str}")
+    logger.debug("Running command: %s", cmd_str)
     if cwd:
-        logger.debug(f"  in directory: {cwd}")
+        logger.debug("  in directory: %s", cwd)
 
     try:
         if capture_output:
@@ -214,10 +214,10 @@ async def run_cmd(
         ) from exc
 
     if check and returncode != 0:
-        logger.error(f"Command failed: {cmd_str}")
-        logger.error(f"  Exit code: {returncode}")
-        logger.error(f"  Stdout: {stdout}")
-        logger.error(f"  Stderr: {stderr}")
+        logger.error("Command failed: %s", cmd_str)
+        logger.error("  Exit code: %s", returncode)
+        logger.error("  Stdout: %s", stdout)
+        logger.error("  Stderr: %s", stderr)
         raise ShellCommandException(  # noqa: TRY003
             f"Command failed with exit code {returncode}: {cmd_str}"
         )

--- a/src/cloud_autopkg_runner/shell.py
+++ b/src/cloud_autopkg_runner/shell.py
@@ -9,8 +9,8 @@ import asyncio
 import contextlib
 import shlex
 
-from cloud_autopkg_runner import logger
 from cloud_autopkg_runner.exceptions import ShellCommandException
+from cloud_autopkg_runner.logging_config import get_logger
 
 
 def _normalize_cmd(cmd: str | list[str]) -> list[str]:
@@ -61,6 +61,7 @@ async def _run_and_capture(
             - stdout (str): The standard output of the command.
             - stderr (str): The standard error of the command.
     """
+    logger = get_logger(__name__)
     returncode: int = -1
 
     proc = await asyncio.create_subprocess_exec(
@@ -114,6 +115,7 @@ async def _run_without_capture(
             - stdout (str): An empty string ("").
             - stderr (str): An empty string ("").
     """
+    logger = get_logger(__name__)
     returncode: int = -1
 
     proc = await asyncio.create_subprocess_exec(*cmd, cwd=cwd)
@@ -183,6 +185,7 @@ async def run_cmd(
             - An `OSError` occurs during subprocess creation.
             - Any other unexpected exception occurs during command execution.
     """
+    logger = get_logger(__name__)
     cmd_list = _normalize_cmd(cmd)
     cmd_str = " ".join(cmd_list)
 

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -90,21 +90,6 @@ def test_appconfig_set_config_multiple() -> None:
     assert AppConfig.verbosity_str() == "-v"
 
 
-def test_appconfig_initializes_logger() -> None:
-    """Test logging initialization."""
-    AppConfig.initialize_logger()
-    assert AppConfig.log_file() is None
-
-
-def test_appconfig_initializes_logger_with_file(tmp_path: Path) -> None:
-    """Test logging initialization."""
-    AppConfig._log_file = tmp_path / "test.log"
-    AppConfig.initialize_logger()
-
-    assert AppConfig.log_file() is not None
-    assert AppConfig.log_file().exists()
-
-
 @pytest.mark.parametrize(
     ("recipe_name", "expected_names"),
     [

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,67 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from cloud_autopkg_runner.logging_config import initialize_logger
+
+
+@pytest.mark.parametrize(
+    ("verbosity_level", "expected_level"),
+    [
+        (0, logging.ERROR),  # Level should be ERROR
+        (1, logging.WARNING),  # Level should be WARNING
+        (2, logging.INFO),  # Level should be INFO
+        (3, logging.DEBUG),  # Level should be DEBUG
+    ],
+)
+def test_console_handler_levels(verbosity_level: int, expected_level: int) -> None:
+    """Test that verbosity levels are set correctly."""
+    initialize_logger(verbosity_level=verbosity_level, log_file=None)
+
+    logger = logging.getLogger()
+
+    # Get the most recent StreamHandler (console handler)
+    console_handler = next(
+        (h for h in logger.handlers if isinstance(h, logging.StreamHandler)), None
+    )
+
+    assert console_handler is not None
+    assert console_handler.level == expected_level
+
+
+def test_logs_to_console_but_not_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test logging without a log file."""
+    log_file = tmp_path / "test.log"
+
+    # Initialize logger with no file output
+    initialize_logger(verbosity_level=1, log_file=None)
+
+    with caplog.at_level(logging.DEBUG):
+        logging.getLogger().info("Hello, console")
+
+    # Assert message is captured (i.e. was logged)
+    assert any("Hello, console" in message for message in caplog.messages)
+
+    # Assert that log file was not created
+    assert not log_file.exists()
+
+
+def test_logs_to_file(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Test that log messages are written to the specified file."""
+    log_file: Path = tmp_path / "test.log"
+
+    initialize_logger(verbosity_level=1, log_file=str(log_file))
+
+    with caplog.at_level(logging.DEBUG):
+        logging.getLogger().info("This should go to both console and file")
+
+    # Sanity check: message is in captured logs
+    assert any("This should go to both console and file" in m for m in caplog.messages)
+
+    # Now assert the message is also in the file
+    assert log_file.exists()
+    contents = log_file.read_text()
+    assert "This should go to both console and file" in contents

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "cloud-autopkg-runner"
-version = "0.9.9"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Remove the `logger` global variable and properly configure the logging functions, removing them from `__init__.py`.

`initialize_logger()` is now part of the `logging_config` module.