### PR TITLE
find_recipe now look for a recipe through all folders 🖤 

### DIFF
--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -256,9 +256,9 @@ class Recipe:
         for lookup_path in lookup_dirs:
             path = lookup_path.expanduser()
             for filename in possible_filenames:
-                recipe_path = path / filename
-                if recipe_path.exists():
-                    return recipe_path
+                for recipe_path in path.rglob(filename):
+                    if recipe_path.exists():
+                        return recipe_path
 
         raise RecipeLookupException(recipe_name)
 


### PR DESCRIPTION
This change addresses an issue with the **find_recipe** method in the **Recipe** class. 

Prior to this fix, **find_recipe** was unable to locate any recipes from **autopkg_preferences.recipe_search_dirs**.

The issue stemmed from the structure of **autopkg_preferences.recipe_search_dirs**, where **recipe_path = path / filename** would never resolve to an existing path.