### PR TITLE
Fix recursive search, Change Recipe() parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
 
 [project]
 name = "cloud-autopkg-runner"
-version = "0.13.0"
+version = "0.13.1"
 description = "A Python library designed to level-up your AutoPkg automations with a focus on CI/CD performance."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
 
 [project]
 name = "cloud-autopkg-runner"
-version = "0.12.1"
+version = "0.13.0"
 description = "A Python library designed to level-up your AutoPkg automations with a focus on CI/CD performance."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*" = ["S101", "D100", "PLR2004", "ANN401", "SLF001"]
+"tests/**/*" = ["S101", "S108", "D100", "PLR2004", "ANN401", "SLF001"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/cloud_autopkg_runner/__init__.py
+++ b/src/cloud_autopkg_runner/__init__.py
@@ -14,9 +14,11 @@ Key features include:
 """
 
 from .autopkg_prefs import AutoPkgPrefs
+from .recipe_finder import RecipeFinder
 from .settings import settings
 
 __all__ = [
     "AutoPkgPrefs",
+    "RecipeFinder",
     "settings",
 ]

--- a/src/cloud_autopkg_runner/__main__.py
+++ b/src/cloud_autopkg_runner/__main__.py
@@ -30,7 +30,6 @@ from cloud_autopkg_runner.exceptions import (
     InvalidFileContents,
     InvalidJsonContents,
     RecipeException,
-    RecipeLookupException,
 )
 from cloud_autopkg_runner.file_utils import create_dummy_files
 from cloud_autopkg_runner.logging_config import get_logger, initialize_logger
@@ -121,13 +120,8 @@ def _generate_recipe_list(args: Namespace) -> set[str]:
 
 async def _get_recipe_path(recipe_name: str) -> Path:
     """Helper function to asynchronously find a recipe path."""
-    try:
-        finder = RecipeFinder()
-        return await finder.find_recipe(recipe_name)
-    except RecipeLookupException:
-        logger = get_logger(__name__)
-        logger.exception("Failed to find recipe: %s", recipe_name)
-        raise
+    finder = RecipeFinder()
+    return await finder.find_recipe(recipe_name)
 
 
 def _parse_arguments() -> Namespace:

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -27,6 +27,12 @@ from cloud_autopkg_runner.exceptions import (
 from cloud_autopkg_runner.recipe import Recipe
 
 
+@pytest.fixture(autouse=True)
+def mock_settings() -> None:
+    """Mock the settings module to avoid actual file operations."""
+    settings.report_dir = Path("/tmp/report_dir")
+
+
 def test_apply_args_to_settings(tmp_path: Path) -> None:
     """Test that _apply_args_to_settings correctly sets settings."""
     args = Namespace(

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -2,10 +2,11 @@
 
 import json
 import os
+import plistlib
 import sys
 from argparse import Namespace
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -14,13 +15,16 @@ from cloud_autopkg_runner.__main__ import (
     _apply_args_to_settings,
     _create_recipe,
     _generate_recipe_list,
+    _get_recipe_path,
     _parse_arguments,
 )
 from cloud_autopkg_runner.exceptions import (
     InvalidFileContents,
     InvalidJsonContents,
     RecipeException,
+    RecipeLookupException,
 )
+from cloud_autopkg_runner.recipe import Recipe
 
 
 def test_apply_args_to_settings(tmp_path: Path) -> None:
@@ -166,20 +170,24 @@ def test_parse_arguments_diff_syntax() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_recipe_success() -> None:
-    """Should return a Recipe object when creation succeeds."""
-    with (
-        patch("cloud_autopkg_runner.__main__.Recipe") as mock_recipe,
-        patch("cloud_autopkg_runner.__main__.settings") as mock_settings,
+async def test_create_recipe_success(tmp_path: Path) -> None:
+    """Test that _create_recipe successfully creates a Recipe object."""
+    plist_content = {
+        "Description": "Test recipe",
+        "Identifier": "com.example.test",
+        "Input": {"NAME": "TestRecipe"},
+        "Process": [],
+        "MinimumVersion": "",
+        "ParentRecipe": "",
+    }
+    recipe_path = tmp_path / "test_recipe.recipe"
+    recipe_path.write_bytes(plistlib.dumps(plist_content))
+    mock_get_recipe_path = AsyncMock(return_value=recipe_path)
+    with patch(
+        "cloud_autopkg_runner.__main__._get_recipe_path", new=mock_get_recipe_path
     ):
-        mock_settings.report_dir = "/mock/report_dir"
-        mock_instance = MagicMock()
-        mock_recipe.return_value = mock_instance
-
-        result = await _create_recipe("good_recipe")
-
-        mock_recipe.assert_called_once_with("good_recipe", "/mock/report_dir")
-        assert result == mock_instance
+        recipe = await _create_recipe("test_recipe")
+        assert isinstance(recipe, Recipe)
 
 
 @pytest.mark.asyncio
@@ -222,3 +230,31 @@ async def test_create_recipe_recipe_exception() -> None:
             "Failed to create recipe: %s", "exception_recipe"
         )
         assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_path_success(tmp_path: Path) -> None:
+    """Test that _get_recipe_path returns the correct path to a recipe."""
+    recipe_path = tmp_path / "test_recipe.recipe"
+    recipe_path.write_text('{"key": "value"}')
+    with patch(
+        "cloud_autopkg_runner.__main__.RecipeFinder.find_recipe",
+        new_callable=AsyncMock,
+        return_value=recipe_path,
+    ):
+        path = await _get_recipe_path("test_recipe")
+        assert path == recipe_path
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_path_recipe_lookup_exception() -> None:
+    """Test that _get_recipe_path raises RecipeLookupException."""
+    with (
+        patch(
+            "cloud_autopkg_runner.__main__.RecipeFinder.find_recipe",
+            new_callable=AsyncMock,
+            side_effect=RecipeLookupException("Recipe not found"),
+        ),
+        pytest.raises(RecipeLookupException),
+    ):
+        await _get_recipe_path("test_recipe")

--- a/tests/test_recipe_finder.py
+++ b/tests/test_recipe_finder.py
@@ -78,7 +78,10 @@ def test_path_within_depth_outside_base(tmp_path: Path) -> None:
     )
 
 
-def test_find_recursively_found(recipe_finder: RecipeFinder, tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_find_recursively_found(
+    recipe_finder: RecipeFinder, tmp_path: Path
+) -> None:
     """Test _find_recursively method when the target file is found."""
     search_dir = tmp_path / "search"
     search_dir.mkdir(parents=True, exist_ok=True)
@@ -86,20 +89,21 @@ def test_find_recursively_found(recipe_finder: RecipeFinder, tmp_path: Path) -> 
     target_file = search_dir / "subdir" / "MyRecipe.recipe"
     target_file.write_text("Recipe content")
 
-    found_path = recipe_finder._find_recursively(
+    found_path = await recipe_finder._find_recursively(
         search_dir, "MyRecipe.recipe", recipe_finder.max_recursion_depth
     )
     assert found_path == target_file
 
 
-def test_find_recursively_not_found(
+@pytest.mark.asyncio
+async def test_find_recursively_not_found(
     recipe_finder: RecipeFinder, tmp_path: Path
 ) -> None:
     """Test _find_recursively method when the target file is not found."""
     search_dir = tmp_path / "search"
     search_dir.mkdir(parents=True, exist_ok=True)
 
-    found_path = recipe_finder._find_recursively(
+    found_path = await recipe_finder._find_recursively(
         search_dir, "NonExistent.recipe", recipe_finder.max_recursion_depth
     )
     assert found_path is None
@@ -127,7 +131,8 @@ def test_find_in_directory_not_found(
     assert found_path is None
 
 
-def test_find_in_directory_recursively_found(
+@pytest.mark.asyncio
+async def test_find_in_directory_recursively_found(
     recipe_finder: RecipeFinder, tmp_path: Path
 ) -> None:
     """Test that the target file is found recursively."""
@@ -137,26 +142,28 @@ def test_find_in_directory_recursively_found(
     target_file = search_dir / "subdir" / "MyRecipe.recipe"
     target_file.write_text("Recipe content")
 
-    found_path = recipe_finder._find_in_directory_recursively(
+    found_path = await recipe_finder._find_in_directory_recursively(
         search_dir, ["MyRecipe.recipe"]
     )
     assert found_path == target_file
 
 
-def test_find_in_directory_recursively_not_found(
+@pytest.mark.asyncio
+async def test_find_in_directory_recursively_not_found(
     recipe_finder: RecipeFinder, tmp_path: Path
 ) -> None:
     """Test that the target file is not found recursively."""
     search_dir = tmp_path / "search"
     search_dir.mkdir(parents=True, exist_ok=True)
 
-    found_path = recipe_finder._find_in_directory_recursively(
+    found_path = await recipe_finder._find_in_directory_recursively(
         search_dir, ["NonExistent.recipe"]
     )
     assert found_path is None
 
 
-def test_search_directory_direct_match(
+@pytest.mark.asyncio
+async def test_search_directory_direct_match(
     recipe_finder: RecipeFinder, tmp_path: Path
 ) -> None:
     """Test _search_directory method with a direct match."""
@@ -165,11 +172,12 @@ def test_search_directory_direct_match(
     target_file = search_dir / "MyRecipe.recipe"
     target_file.write_text("Recipe content")
 
-    found_path = recipe_finder._search_directory(search_dir, ["MyRecipe.recipe"])
+    found_path = await recipe_finder._search_directory(search_dir, ["MyRecipe.recipe"])
     assert found_path == target_file
 
 
-def test_search_directory_recursive_match(
+@pytest.mark.asyncio
+async def test_search_directory_recursive_match(
     recipe_finder: RecipeFinder, tmp_path: Path
 ) -> None:
     """Test _search_directory method with a recursive match."""
@@ -179,32 +187,39 @@ def test_search_directory_recursive_match(
     target_file = search_dir / "subdir" / "MyRecipe.recipe"
     target_file.write_text("Recipe content")
 
-    found_path = recipe_finder._search_directory(search_dir, ["MyRecipe.recipe"])
+    found_path = await recipe_finder._search_directory(search_dir, ["MyRecipe.recipe"])
     assert found_path == target_file
 
 
-def test_search_directory_not_found(
+@pytest.mark.asyncio
+async def test_search_directory_not_found(
     recipe_finder: RecipeFinder, tmp_path: Path
 ) -> None:
     """Test _search_directory method when the target file is not found."""
     search_dir = tmp_path / "search"
     search_dir.mkdir(parents=True, exist_ok=True)
 
-    found_path = recipe_finder._search_directory(search_dir, ["NonExistent.recipe"])
+    found_path = await recipe_finder._search_directory(
+        search_dir, ["NonExistent.recipe"]
+    )
     assert found_path is None
 
 
-def test_find_recipe_direct_match(recipe_finder: RecipeFinder, tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_find_recipe_direct_match(
+    recipe_finder: RecipeFinder, tmp_path: Path
+) -> None:
     """Test find_recipe method with a direct match in lookup directories."""
     recipe_file = tmp_path / "override" / "MyRecipe.recipe"
     tmp_path.joinpath("override").mkdir(parents=True)
     recipe_file.write_text("Recipe content")
 
-    found_path = recipe_finder.find_recipe("MyRecipe.recipe")
+    found_path = await recipe_finder.find_recipe("MyRecipe.recipe")
     assert found_path == recipe_file
 
 
-def test_find_recipe_recursive_match(
+@pytest.mark.asyncio
+async def test_find_recipe_recursive_match(
     recipe_finder: RecipeFinder, tmp_path: Path
 ) -> None:
     """Test find_recipe method with a recursive match in lookup directories."""
@@ -212,17 +227,19 @@ def test_find_recipe_recursive_match(
     tmp_path.joinpath("search", "subdir").mkdir(parents=True)
     recipe_file.write_text("Recipe content")
 
-    found_path = recipe_finder.find_recipe("MyRecipe.recipe")
+    found_path = await recipe_finder.find_recipe("MyRecipe.recipe")
     assert found_path == recipe_file
 
 
-def test_find_recipe_not_found(recipe_finder: RecipeFinder) -> None:
+@pytest.mark.asyncio
+async def test_find_recipe_not_found(recipe_finder: RecipeFinder) -> None:
     """Test find_recipe method when the recipe is not found."""
     with pytest.raises(RecipeLookupException):
-        recipe_finder.find_recipe("NonExistentRecipe")
+        await recipe_finder.find_recipe("NonExistentRecipe")
 
 
-def test_find_recipe_prefers_override(
+@pytest.mark.asyncio
+async def test_find_recipe_prefers_override(
     recipe_finder: RecipeFinder, tmp_path: Path
 ) -> None:
     """Test that the override directory is preferred over the search directory."""
@@ -235,11 +252,12 @@ def test_find_recipe_prefers_override(
     override_recipe.write_text("Override Recipe")
     search_recipe.write_text("Search Recipe")
 
-    found_path = recipe_finder.find_recipe("MyRecipe.recipe")
+    found_path = await recipe_finder.find_recipe("MyRecipe.recipe")
     assert found_path == override_recipe
 
 
-def test_find_recipe_handles_tilde_expansion(
+@pytest.mark.asyncio
+async def test_find_recipe_handles_tilde_expansion(
     recipe_finder: RecipeFinder, tmp_path: Path
 ) -> None:
     """Test that find_recipe correctly handles tilde expansion in paths."""
@@ -259,11 +277,12 @@ def test_find_recipe_handles_tilde_expansion(
         tmp_path.joinpath("override").mkdir(parents=True)
         recipe_file.write_text("Recipe content")
 
-        found_path = recipe_finder.find_recipe("MyRecipe.recipe")
+        found_path = await recipe_finder.find_recipe("MyRecipe.recipe")
         assert found_path == recipe_file
 
 
-def test_find_recipe_custom_recursion_depth(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_find_recipe_custom_recursion_depth(tmp_path: Path) -> None:
     """Test find_recipe with a custom recursion depth."""
     mock_prefs = MagicMock()
     mock_prefs.recipe_override_dirs = [tmp_path / "override"]
@@ -282,9 +301,9 @@ def test_find_recipe_custom_recursion_depth(tmp_path: Path) -> None:
         target_file.write_text("Recipe content")
 
         with pytest.raises(RecipeLookupException):
-            recipe_finder.find_recipe("MyRecipe.recipe")
+            await recipe_finder.find_recipe("MyRecipe.recipe")
 
         recipe_finder = RecipeFinder(max_recursion_depth=2)
         recipe_finder.logger = MagicMock()
-        found_path = recipe_finder.find_recipe("MyRecipe.recipe")
+        found_path = await recipe_finder.find_recipe("MyRecipe.recipe")
         assert found_path == target_file

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "cloud-autopkg-runner"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "cloud-autopkg-runner"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
- Fix an issue where the recursive recipe search would fail.
- Change the `recipe_name` parameter to `recipe_path` in the Recipe() class