### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   lock_file:
     runs-on: ubuntu-latest
@@ -57,6 +60,9 @@ jobs:
   unit_tests:
     runs-on: macos-latest
     needs: [lock_file]
+    permissions:
+      contents: read
+      statuses: write
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
 
 [project]
 name = "cloud-autopkg-runner"
-version = "0.13.2"
+version = "0.13.3"
 description = "A Python library designed to level-up your AutoPkg automations with a focus on CI/CD performance."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
 
 [project]
 name = "cloud-autopkg-runner"
-version = "0.13.1"
+version = "0.13.2"
 description = "A Python library designed to level-up your AutoPkg automations with a focus on CI/CD performance."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "cloud-autopkg-runner"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "cloud-autopkg-runner"
-version = "0.13.1"
+version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Potential fix for [https://github.com/MScottBlake/cloud-autopkg-runner/security/code-scanning/7](https://github.com/MScottBlake/cloud-autopkg-runner/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal required permissions for all jobs. Based on the workflow's actions, the `contents: read` permission is sufficient for most jobs, as they primarily involve checking out the repository and running commands. For the `unit_tests` job, which uploads test results and coverage reports, additional permissions for `contents: read` and `statuses: write` are required to interact with Codecov.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
