### PR TITLE
Fix `_placeholder_files_created` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dev = [
 
 [project]
 name = "cloud-autopkg-runner"
-version = "0.15.2"
+version = "0.15.3"
 description = "A Python library designed to level-up your AutoPkg automations with a focus on CI/CD performance."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dev = [
 
 [project]
 name = "cloud-autopkg-runner"
-version = "0.15.3"
+version = "0.15.4"
 description = "A Python library designed to level-up your AutoPkg automations with a focus on CI/CD performance."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -261,7 +261,10 @@ class Recipe:
         to simulate an existing cache. It uses the `_placeholder_files_created`
         variable to prevent running multiple times.
         """
-        if not self._placeholder_files_created:
+        if (
+            not hasattr(self, "_placeholder_files_created")
+            or self._placeholder_files_created is not True
+        ):
             await file_utils.create_placeholder_files([self.name])
             self._placeholder_files_created = True
 

--- a/uv.lock
+++ b/uv.lock
@@ -463,7 +463,7 @@ wheels = [
 
 [[package]]
 name = "cloud-autopkg-runner"
-version = "0.15.3"
+version = "0.15.4"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -463,7 +463,7 @@ wheels = [
 
 [[package]]
 name = "cloud-autopkg-runner"
-version = "0.15.2"
+version = "0.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Fixes the "AttributeError: 'Recipe' object has no attribute '_placeholder_files_created'" error message that was caused by a bad if statement.