### PR TITLE
Add GitClient class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,11 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "hatch>=1.14.0",
     "pre-commit>=4.1.0",
     "pyright>=1.1.397",
     "pytest-asyncio>=0.26.0",
     "pytest-cov>=6.0.0",
-    "ruff>=0.11.0",
+    "ruff>=0.12.7",
     "types-aioboto3-lite[s3]>=1.38.10",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
 
 [project]
 name = "cloud-autopkg-runner"
-version = "0.16.1"
+version = "0.17.0"
 description = "A Python library designed to level-up your AutoPkg automations with a focus on CI/CD performance."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/cloud_autopkg_runner/__init__.py
+++ b/src/cloud_autopkg_runner/__init__.py
@@ -16,6 +16,7 @@ Key features include:
 from .settings import Settings  # noqa: I001
 
 from .autopkg_prefs import AutoPkgPrefs
+from .git_client import GitClient
 from .metadata_cache import get_cache_plugin
 from .recipe import Recipe
 from .recipe_finder import RecipeFinder
@@ -23,6 +24,7 @@ from .recipe_report import RecipeReport
 
 __all__ = [
     "AutoPkgPrefs",
+    "GitClient",
     "Recipe",
     "RecipeFinder",
     "RecipeReport",

--- a/src/cloud_autopkg_runner/exceptions.py
+++ b/src/cloud_autopkg_runner/exceptions.py
@@ -205,3 +205,153 @@ class ShellCommandException(AutoPkgRunnerException):
     This exception serves as a base class for more specific exceptions
     related to shell command execution.
     """
+
+
+# Git
+class GitError(AutoPkgRunnerException):
+    """Base exception for all Git-related errors.
+
+    This class serves as a parent for more specific exceptions that
+    can occur during Git operations.
+    """
+
+
+class GitRepoDoesNotExistError(GitError):
+    """Exception raised when a specified Git repository path does not exist.
+
+    This indicates that the directory provided as a repository path
+    does not exist on the file system.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Initializes GitRepoDoesNotExistError.
+
+        Args:
+            path: The path that was expected to be a Git repository
+                but does not exist.
+        """
+        super().__init__(f"Repository path does not exist: {path}")
+
+
+class PathNotGitRepoError(GitError):
+    """Exception raised when a specified path is not a Git repository.
+
+    This indicates that the directory exists, but it does not contain
+    the necessary Git repository structure (e.g., a `.git` directory).
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Initializes PathNotGitRepoError.
+
+        Args:
+            path: The path that was expected to be a Git repository
+                but lacks the Git repository structure.
+        """
+        super().__init__(f"Path does not appear to be a Git repository: {path}")
+
+
+class GitDefaultBranchError(GitError):
+    """Exception raised when the default branch for a remote cannot be determined.
+
+    This can occur if the remote does not exist, or its `HEAD` reference is not
+    clearly defined in `git remote show` output.
+    """
+
+    def __init__(self, remote_name: str) -> None:
+        """Initializes GitDefaultBranchError.
+
+        Args:
+            remote_name: The name of the remote for which the default branch
+                         could not be determined.
+        """
+        super().__init__(
+            f"Could not determine default branch for remote '{remote_name}'."
+        )
+
+
+class GitMergeError(GitError):
+    """Exception raised when a Git merge operation fails.
+
+    This typically indicates a conflict, or that the target branch was not
+    currently checked out when the merge was attempted.
+    """
+
+    def __init__(self, target_branch: str, current_branch: str) -> None:
+        """Initializes GitMergeError.
+
+        Args:
+            target_branch: The branch that was intended to be the merge target.
+            current_branch: The branch that was actually checked out when the merge was
+                attempted.
+        """
+        super().__init__(
+            f"Cannot merge: '{target_branch}' is not currently checked out. "
+            f"Current branch is '{current_branch}'."
+        )
+
+
+class GitWorktreeError(GitError):
+    """Base exception for errors specific to Git worktree operations.
+
+    This exception is raised when a generic failure occurs during
+    a `git worktree` command execution.
+    """
+
+    def __init__(self, cmd_str: str) -> None:
+        """Initializes GitWorktreeError.
+
+        Args:
+            cmd_str: The string representation of the Git command that failed.
+        """
+        super().__init__(f"Git worktree command failed: '{cmd_str}'")
+
+
+class GitWorktreeCreationError(GitWorktreeError):
+    """Exception raised when a Git worktree fails to be created.
+
+    This indicates that the `git worktree add` command did not result
+    in a valid new worktree at the specified path.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Initializes GitWorktreeCreationError.
+
+        Args:
+            path: The intended path for the new worktree where creation failed.
+        """
+        super().__init__(f"Failed to create worktree at {path}")
+
+
+class GitWorktreeMissingPathError(GitWorktreeError):
+    """Exception raised when a specified worktree path does not exist.
+
+    This is typically used when attempting to operate on an existing worktree
+    (e.g., `remove`, `move`, `lock`, `unlock`) and the path provided
+    does not point to an existing directory.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Initializes GitWorktreeMissingPathError.
+
+        Args:
+            path: The path that was expected to point to an existing worktree
+                but does not exist.
+        """
+        super().__init__(f"Worktree directory does not exist: {path}")
+
+
+class GitWorktreeMoveError(GitWorktreeError):
+    """Exception raised when a Git worktree fails to be moved.
+
+    This indicates that the `git worktree move` command did not
+    successfully relocate the worktree from its old path to the new one.
+    """
+
+    def __init__(self, old_path: Path, new_path: Path) -> None:
+        """Initializes GitWorktreeMoveError.
+
+        Args:
+            old_path: The original path of the worktree.
+            new_path: The intended new path for the worktree.
+        """
+        super().__init__(f"Failed to move worktree from {old_path} to {new_path}")

--- a/src/cloud_autopkg_runner/git_client.py
+++ b/src/cloud_autopkg_runner/git_client.py
@@ -1,0 +1,906 @@
+"""Module for managing Git repositories and worktrees asynchronously.
+
+This module provides a robust and asynchronous interface for performing common
+Git operations, such as initializing, adding, committing, checking out branches,
+and managing worktrees. It leverages the `shell` module for non-blocking
+command execution and includes comprehensive error handling.
+"""
+
+from pathlib import Path
+
+from cloud_autopkg_runner import logging_config, shell
+from cloud_autopkg_runner.exceptions import (
+    GitDefaultBranchError,
+    GitError,
+    GitMergeError,
+    GitRepoDoesNotExistError,
+    GitWorktreeCreationError,
+    GitWorktreeMissingPathError,
+    GitWorktreeMoveError,
+    PathNotGitRepoError,
+    ShellCommandException,
+)
+
+
+class GitClient:
+    """Manages Git repository operations and worktrees asynchronously.
+
+    This class provides methods to interact with a Git repository, allowing
+    for common Git commands and specific Git worktree management. All
+    operations are asynchronous and non-blocking, making them suitable
+    for integration into `asyncio` applications.
+
+    Attributes:
+        repo_path (Path): The path to the main Git repository.
+        _logger (logging.Logger): The logger instance for this class.
+    """
+
+    def __init__(self, repo_path: str | Path) -> None:
+        """Initializes the GitClient.
+
+        Args:
+            repo_path: The path to the main Git repository (absolute or relative).
+                For a new repository, this is the path where the .git
+                directory will be initialized.
+        """
+        self.repo_path = Path(repo_path).resolve()
+        self._logger = logging_config.get_logger(__name__)
+
+        if not self.repo_path.is_dir():
+            raise GitRepoDoesNotExistError(self.repo_path)
+
+    async def _run_git_cmd(
+        self,
+        subcommand: list[str],
+        *,
+        cwd: str | Path | None = None,
+        check: bool = True,
+        capture_output: bool = True,
+        timeout: int | None = None,
+    ) -> tuple[int, str, str]:
+        """Executes a Git command asynchronously.
+
+        This private helper method forms the core of Git command execution.
+        It constructs the full `git` command, sets the working directory,
+        and handles potential `ShellCommandException` by re-raising them
+        as `GitError` for consistent error handling within this class.
+
+        Args:
+            subcommand: A list of strings representing the Git subcommand
+                and its arguments (e.g., `["init"]`, `["add", "."]`).
+            cwd: The working directory for the command. Defaults to `self.repo_path`.
+            check: If `True`, raises `ShellCommandException` on non-zero exit code.
+                Set to `False` if you want to inspect the return code manually.
+            capture_output: If `True`, captures stdout/stderr. If `False`,
+                output is inherited from the parent process.
+            timeout: Optional timeout in seconds for the command.
+
+        Returns:
+            A tuple containing:
+                - returncode (int): The exit code of the command.
+                - stdout (str): The standard output.
+                - stderr (str): The standard error.
+
+        Raises:
+            GitError: If an underlying `ShellCommandException` occurs, or if
+                the repository path does not exist when a Git command is attempted.
+        """
+        full_cmd = ["git", *subcommand]
+        effective_cwd = Path(cwd).resolve() if cwd else self.repo_path
+
+        if not effective_cwd.exists():
+            raise GitRepoDoesNotExistError(effective_cwd)
+
+        try:
+            return await shell.run_cmd(
+                full_cmd,
+                cwd=str(effective_cwd),
+                check=check,
+                capture_output=capture_output,
+                timeout=timeout,
+            )
+        except ShellCommandException as exc:
+            raise GitError(" ".join(full_cmd)) from exc
+
+    async def _check_is_git_repo(self, path: Path) -> None:
+        """Checks if a given path is a valid Git repository.
+
+        This private helper method performs a quick check by looking for
+        the `.git` directory within the specified path. It raises specific
+        exceptions if the path does not exist or is not a Git repository.
+
+        Args:
+            path: The path to check.
+
+        Raises:
+            GitRepoDoesNotExistError: If the path does not exist.
+            PathNotGitRepoError: If the path exists but is not a Git repository.
+        """
+        if not path.is_dir():
+            raise GitRepoDoesNotExistError(path)
+        if not (path / ".git").exists():
+            raise PathNotGitRepoError(path)
+
+    async def init(
+        self,
+        *,
+        bare: bool = False,
+        initial_branch: str | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        """Initializes a new Git repository.
+
+        Corresponds to `git init`. If `self.repo_path` does not exist,
+        it will be created.
+
+        Args:
+            bare: If `True`, creates a bare repository (uses `--bare`).
+            initial_branch: Specifies the name of the initial branch (uses `-b`).
+                            Defaults to Git's default (usually 'master' or 'main').
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If the repository initialization fails.
+        """
+        if not self.repo_path.exists():
+            self._logger.debug("Creating directory for new repo: %s", self.repo_path)
+            self.repo_path.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["init"]
+        if bare:
+            cmd.append("--bare")
+        if initial_branch:
+            cmd.extend(["-b", initial_branch])
+
+        self._logger.info("Initializing Git repository at %s...", self.repo_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def add(
+        self,
+        paths: str | list[str],
+        *,
+        force: bool = False,
+        update: bool = False,
+        timeout: int | None = None,
+    ) -> None:
+        """Adds file contents to the index.
+
+        Corresponds to `git add <paths>`.
+
+        Args:
+            paths: A single path string or a list of path strings to add.
+                   Use `"."` to add all changes in the current directory.
+            force: Allows adding otherwise ignored files (uses `--force`).
+            update: Only match files that are already indexed (uses `--update`).
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If adding files to the index fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["add"]
+        if force:
+            cmd.append("--force")
+        if update:
+            cmd.append("--update")
+
+        if isinstance(paths, str):
+            cmd.append(paths)
+        else:
+            cmd.extend(paths)
+
+        self._logger.info("Adding files to Git index in %s...", self.repo_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def commit(  # noqa: PLR0913
+        self,
+        message: str,
+        *,
+        allow_empty: bool = False,
+        all_changes: bool = False,
+        no_verify: bool = False,
+        amend: bool = False,
+        author: str | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        """Records changes to the repository.
+
+        Corresponds to `git commit -m <message>`.
+
+        Args:
+            message: The commit message.
+            allow_empty: If `True`, creates a commit even if there are no changes
+                (uses `--allow-empty`).
+            all_changes: If `True`, automatically stage files that have been
+                modified and deleted (uses `--all` or `-a`).
+            no_verify: If `True`, bypass pre-commit and commit-msg hooks
+                (uses `--no-verify`).
+            amend: If `True`, combines the latest commit with the current staged changes
+                (uses `--amend`).
+            author: Specifies the author for the commit in "Author Name <email>" format.
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If the commit operation fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["commit", "-m", message]
+        if allow_empty:
+            cmd.append("--allow-empty")
+        if all_changes:
+            cmd.append("--all")
+        if no_verify:
+            cmd.append("--no-verify")
+        if amend:
+            cmd.append("--amend")
+        if author:
+            cmd.extend([f"--author={author}"])
+
+        self._logger.info("Committing changes in %s...", self.repo_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def branch(
+        self,
+        branch_name: str,
+        *,
+        start_point: str | None = None,
+        force: bool = False,
+        timeout: int | None = None,
+    ) -> None:
+        """Creates a new branch.
+
+        Corresponds to `git branch <branch_name> [start_point]`.
+
+        Args:
+            branch_name: The name of the new branch.
+            start_point: The commit/branch/tag to start the new branch from.
+                         If `None`, it starts from HEAD.
+            force: If `True`, forces creation of the branch even if it already
+                   exists (uses `--force`).
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If branch creation fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["branch"]
+        if force:
+            cmd.append("--force")
+        cmd.append(branch_name)
+        if start_point:
+            cmd.append(start_point)
+
+        self._logger.info("Creating branch '%s' in %s...", branch_name, self.repo_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def merge_branch(  # noqa: PLR0913
+        self,
+        source_branch: str,
+        target_branch: str = "HEAD",
+        *,
+        no_ff: bool = False,
+        no_edit: bool = False,
+        squash: bool = False,  # Added squash option
+        timeout: int | None = None,
+    ) -> None:
+        """Merges a source branch into a target branch.
+
+        Corresponds to `git merge <source_branch>`.
+        The `target_branch` specifies which branch to merge *into* (defaults to current
+        HEAD).
+
+        Args:
+            source_branch: The name of the branch to merge from.
+            target_branch: The name of the branch to merge into. If "HEAD", merges into
+                the current branch. The current branch must be `target_branch` when this
+                method is called.
+            no_ff: If `True`, always create a merge commit even if a fast-forward merge
+                is possible (uses `--no-ff`).
+            no_edit: If `True`, do not launch an editor for the merge commit message
+                (uses `--no-edit`).
+            squash: If `True`, combines all commits from the source branch into a
+                single commit on the target branch (uses `--squash`). Note: This
+                requires a subsequent manual `git commit`.
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If the merge operation fails (e.g., conflicts, target branch not
+                checked out).
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        # Verify that target_branch is currently checked out, unless it is already HEAD
+        if target_branch != "HEAD":
+            current_branch = await self.get_current_branch()
+            if current_branch != target_branch:
+                raise GitMergeError(target_branch, current_branch)
+
+        cmd = ["merge"]
+        if no_ff:
+            cmd.append("--no-ff")
+        if no_edit:
+            cmd.append("--no-edit")
+        if squash:
+            cmd.append("--squash")
+
+        cmd.append(source_branch)
+
+        self._logger.info(
+            "Merging branch '%s' into '%s' in %s...",
+            source_branch,
+            target_branch,
+            self.repo_path,
+        )
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+        self._logger.info("Branch '%s' merged into '%s'.", source_branch, target_branch)
+
+    async def checkout(
+        self,
+        ref: str,
+        *,
+        create_branch: bool = False,
+        orphan: bool = False,
+        timeout: int | None = None,
+    ) -> None:
+        """Switches branches or restores working tree files.
+
+        Corresponds to `git checkout <ref>`.
+
+        Args:
+            ref: The branch, tag, or commit to checkout.
+            create_branch: If `True`, creates a new branch named `ref` and checks it out
+                (uses `-b`).
+            orphan: If `True`, creates a new orphan branch (uses `--orphan`).
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If checkout fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["checkout"]
+        if create_branch:
+            cmd.append("-b")
+        if orphan:
+            cmd.append("--orphan")
+        cmd.append(ref)
+
+        self._logger.info("Checking out '%s' in %s...", ref, self.repo_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def fetch(
+        self,
+        remote: str | None = None,
+        *,
+        prune: bool = False,
+        all_remotes: bool = False,
+        tags: bool = False,
+        timeout: int | None = None,
+    ) -> None:
+        """Downloads objects and refs from another repository.
+
+        Corresponds to `git fetch [remote]`.
+
+        Args:
+            remote: The name of the remote repository to fetch from. If `None`,
+                    fetches from all remotes or the default remote.
+            prune: If `True`, remove any remote-tracking branches which no
+                   longer exist on the remote (uses `--prune`).
+            all_remotes: If `True`, fetches all remotes (uses `--all`).
+            tags: If `True`, fetches all tags from the remote (uses `--tags`).
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If fetching fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["fetch"]
+        if prune:
+            cmd.append("--prune")
+        if all_remotes:
+            cmd.append("--all")
+        if tags:
+            cmd.append("--tags")
+        if remote:
+            cmd.append(remote)
+
+        self._logger.info("Fetching from remote in %s...", self.repo_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def pull(
+        self,
+        remote: str | None = None,
+        branch: str | None = None,
+        *,
+        rebase: bool = False,
+        timeout: int | None = None,
+    ) -> None:
+        """Fetches from and integrates with another repository or a local branch.
+
+        Corresponds to `git pull [remote] [branch]`.
+
+        Args:
+            remote: The remote repository to pull from.
+            branch: The remote branch to pull.
+            rebase: If `True`, rebase the current branch on top of the fetched
+                    branch instead of merging (uses `--rebase`).
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If pulling fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["pull"]
+        if rebase:
+            cmd.append("--rebase")
+        if remote:
+            cmd.append(remote)
+        if branch:
+            cmd.append(branch)
+
+        self._logger.info("Pulling changes in %s...", self.repo_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def push(
+        self,
+        remote: str | None = None,
+        branch: str | None = None,
+        *,
+        force: bool = False,
+        set_upstream: bool = False,
+        timeout: int | None = None,
+    ) -> None:
+        """Updates remote refs along with associated objects.
+
+        Corresponds to `git push [remote] [branch]`.
+
+        Args:
+            remote: The remote repository to push to.
+            branch: The local branch to push. If `None`, pushes the current branch.
+            force: If `True`, forces the push, potentially overwriting remote history
+                   (uses `--force`). Use with caution!
+            set_upstream: If `True`, adds `--set-upstream` to track the remote branch.
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If pushing fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["push"]
+        if force:
+            cmd.append("--force")
+        if set_upstream:
+            cmd.append("--set-upstream")
+        if remote:
+            cmd.append(remote)
+        if branch:
+            cmd.append(branch)
+
+        self._logger.info("Pushing changes from %s...", self.repo_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def status(
+        self,
+        *,
+        short: bool = False,
+        porcelain: bool = False,
+        timeout: int | None = None,
+    ) -> str:
+        """Shows the working tree status.
+
+        Corresponds to `git status`.
+
+        Args:
+            short: If `True`, gives the output in the short-format (uses `--short` or
+                `-s`).
+            porcelain: If `True`, gives the output in an easy-to-parse format
+                designed for scripts (uses `--porcelain`).
+            timeout: Optional timeout for the operation.
+
+        Returns:
+            The standard output of the `git status` command.
+
+        Raises:
+            GitError: If checking status fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["status"]
+        if short:
+            cmd.append("--short")
+        if porcelain:
+            cmd.append("--porcelain")
+
+        self._logger.info("Checking Git status in %s...", self.repo_path)
+        _returncode, stdout, _stderr = await self._run_git_cmd(
+            cmd, cwd=self.repo_path, timeout=timeout
+        )
+        return stdout
+
+    async def get_current_branch(self, timeout: int | None = None) -> str:
+        """Gets the name of the current active branch.
+
+        Corresponds to `git rev-parse --abbrev-ref HEAD`.
+
+        Returns:
+            The name of the current branch.
+
+        Raises:
+            GitError: If unable to determine the current branch.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["rev-parse", "--abbrev-ref", "HEAD"]
+
+        self._logger.info("Getting current branch in %s...", self.repo_path)
+        _returncode, stdout, _stderr = await self._run_git_cmd(
+            cmd, cwd=self.repo_path, timeout=timeout
+        )
+        return stdout.strip()
+
+    async def get_default_branch(
+        self, remote_name: str = "origin", timeout: int | None = None
+    ) -> str:
+        """Gets the default branch name for a given remote.
+
+        This typically queries the remote to find its HEAD reference.
+
+        Corresponds to `git remote show <remote_name>`.
+
+        Args:
+            remote_name: The name of the remote (e.g., "origin").
+            timeout: Optional timeout for the operation.
+
+        Returns:
+            The name of the default branch (e.g., 'main' or 'master').
+
+        Raises:
+            GitError: If unable to determine the default branch,
+                or if the remote does not exist.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["remote", "show", remote_name]
+
+        _returncode, stdout, _stderr = await self._run_git_cmd(
+            cmd, cwd=self.repo_path, timeout=timeout
+        )
+
+        # Parse the output to find the "HEAD branch"
+        for line in stdout.splitlines():
+            if "HEAD branch:" in line:
+                return line.split("HEAD branch:")[1].strip()
+
+        raise GitDefaultBranchError(remote_name)
+
+    async def get_remote_url(
+        self, remote_name: str = "origin", timeout: int | None = None
+    ) -> str:
+        """Gets the URL of a specified remote.
+
+        Corresponds to `git remote get-url <remote_name>`.
+
+        Args:
+            remote_name: The name of the remote (e.g., "origin").
+            timeout: Optional timeout for the operation.
+
+        Returns:
+            The URL of the remote.
+
+        Raises:
+            GitError: If the remote URL cannot be retrieved.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["remote", "get-url", remote_name]
+
+        self._logger.info(
+            "Getting URL for remote '%s' in %s...", remote_name, self.repo_path
+        )
+        _returncode, stdout, _stderr = await self._run_git_cmd(
+            cmd, cwd=self.repo_path, timeout=timeout
+        )
+        return stdout.strip()
+
+    async def add_remote(
+        self,
+        name: str,
+        url: str,
+        *,
+        track_branches: list[str] | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        """Adds a new remote repository.
+
+        Corresponds to `git remote add <name> <url>`.
+
+        Args:
+            name: The name of the new remote.
+            url: The URL of the remote repository.
+            track_branches: Optional list of branches to track from the remote.
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If adding the remote fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["remote", "add"]
+        if track_branches:
+            for branch in track_branches:
+                cmd.extend(["-t", branch])
+        cmd.extend([name, url])
+
+        self._logger.info(
+            "Adding remote '%s' with URL '%s' to %s...", name, url, self.repo_path
+        )
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    # Worktrees
+
+    async def add_worktree(  # noqa: PLR0913
+        self,
+        path: str | Path,
+        branch_or_commit: str,
+        *,
+        force: bool = False,
+        detach: bool = False,
+        checkout_options: list[str] | None = None,
+        timeout: int | None = None,
+    ) -> Path:
+        """Adds a new Git worktree.
+
+        Corresponds to `git worktree add <path> <branch_or_commit>`.
+
+        Args:
+            path: The path where the new worktree will be created.
+            branch_or_commit: The branch, commit hash, or tag to checkout in the
+                new worktree.
+            force: If `True`, creates the worktree even if the path exists and is
+                not empty (uses `--force`).
+            detach: If `True`, detach the HEAD of the new worktree (uses `--detach`).
+            checkout_options: A list of additional options to pass to `git checkout`.
+            timeout: Optional timeout for the operation.
+
+        Returns:
+            The absolute path to the newly created worktree.
+
+        Raises:
+            GitWorktreeCreationError: If the worktree creation fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+        worktree_path = Path(path).resolve()
+
+        cmd = ["worktree", "add"]
+        if force:
+            cmd.append("--force")
+        if detach:
+            cmd.append("--detach")
+        if checkout_options:
+            cmd.extend(checkout_options)
+
+        cmd.extend([str(worktree_path), branch_or_commit])
+
+        self._logger.info(
+            "Adding new Git worktree at %s from %s...", worktree_path, branch_or_commit
+        )
+        try:
+            _returncode, stdout, stderr = await self._run_git_cmd(
+                cmd, cwd=self.repo_path, timeout=timeout
+            )
+        except GitError as exc:
+            raise GitWorktreeCreationError(worktree_path) from exc
+
+        if not worktree_path.is_dir() or not (worktree_path / ".git").exists():
+            self._logger.error(
+                "Failed to verify worktree creation at %s. Stdout: %s, Stderr: %s",
+                worktree_path,
+                stdout,
+                stderr,
+            )
+            raise GitWorktreeCreationError(worktree_path)
+
+        return worktree_path
+
+    async def list_worktrees(
+        self, timeout: int | None = None
+    ) -> list[tuple[Path, str]]:
+        """Lists existing Git worktrees.
+
+        Corresponds to `git worktree list --porcelain`.
+
+        Returns:
+            A list of tuples, where each tuple contains:
+                - Path: The absolute path to the worktree.
+                - str: The HEAD commit or branch of the worktree.
+
+        Raises:
+            GitError: If listing worktrees fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+        cmd = ["worktree", "list", "--porcelain"]
+
+        self._logger.debug("Listing Git worktrees...")
+        _returncode, stdout, _stderr = await self._run_git_cmd(
+            cmd, cwd=self.repo_path, timeout=timeout
+        )
+
+        worktrees: list[tuple[Path, str]] = []
+        current_worktree_path: Path | None = None
+        current_head: str | None = None
+
+        for line in stdout.splitlines():
+            if line.startswith("worktree "):
+                # Start of a new worktree entry
+                if current_worktree_path and current_head:
+                    worktrees.append((current_worktree_path, current_head))
+                current_worktree_path = Path(line.split(" ", 1)[1]).resolve()
+                current_head = None  # Reset head for the new worktree
+            elif line.startswith("HEAD "):
+                current_head = line.split(" ", 1)[1]
+            elif line.startswith("branch "):
+                # Extract branch name, e.g., "branch refs/heads/main" -> "main"
+                # This prioritizes branch over bare HEAD if both are present in output
+                branch_ref = line.split(" ", 1)[1]
+                if branch_ref.startswith("refs/heads/"):
+                    current_head = branch_ref.replace("refs/heads/", "")
+                else:
+                    current_head = branch_ref  # Fallback for other ref types
+
+        # Add the last parsed worktree
+        if current_worktree_path and current_head:
+            worktrees.append((current_worktree_path, current_head))
+
+        self._logger.debug("Found %d worktrees.", len(worktrees))
+        return worktrees
+
+    async def remove_worktree(
+        self, path: str | Path, *, force: bool = False, timeout: int | None = None
+    ) -> None:
+        """Removes an existing Git worktree.
+
+        Corresponds to `git worktree remove <path>`.
+
+        Args:
+            path: The path to the worktree to remove.
+            force: If `True`, remove the worktree even if it has unstaged changes
+                or uncommitted changes (uses `--force`).
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If the worktree removal fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+        worktree_path = Path(path).resolve()
+
+        cmd = ["worktree", "remove"]
+        if force:
+            cmd.append("--force")
+        cmd.append(str(worktree_path))
+
+        self._logger.info("Removing Git worktree at %s...", worktree_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+        if worktree_path.exists():
+            self._logger.warning(
+                "Worktree directory still exists after removal: %s", worktree_path
+            )
+
+    async def prune_worktrees(self, timeout: int | None = None) -> None:
+        """Prunes stale Git worktree information.
+
+        Corresponds to `git worktree prune`. This removes defunct worktree
+        registrations from the main repository's `.git/worktrees` directory.
+
+        Args:
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If pruning fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+
+        cmd = ["worktree", "prune"]
+
+        self._logger.info("Pruning stale Git worktree entries...")
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def move_worktree(
+        self, old_path: str | Path, new_path: str | Path, timeout: int | None = None
+    ) -> Path:
+        """Moves an existing Git worktree to a new location.
+
+        Corresponds to `git worktree move <old_path> <new_path>`.
+
+        Args:
+            old_path: The current path of the worktree.
+            new_path: The new desired path for the worktree.
+            timeout: Optional timeout for the operation.
+
+        Returns:
+            The absolute path to the newly moved worktree.
+
+        Raises:
+            GitWorktreeMissingPathError: If the `old_path` does not exist.
+            GitWorktreeMoveError: If the worktree move operation fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+        old_worktree_path = Path(old_path).resolve()
+        new_worktree_path = Path(new_path).resolve()
+
+        if not old_worktree_path.is_dir():
+            raise GitWorktreeMissingPathError(old_worktree_path)
+
+        cmd = ["worktree", "move", str(old_worktree_path), str(new_worktree_path)]
+
+        self._logger.info(
+            "Moving Git worktree from %s to %s...", old_worktree_path, new_worktree_path
+        )
+        try:
+            await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+        except GitError as exc:
+            raise GitWorktreeMoveError(old_worktree_path, new_worktree_path) from exc
+
+        if not new_worktree_path.is_dir() or old_worktree_path.exists():
+            self._logger.error(
+                "Failed to verify worktree move from %s to %s.",
+                old_worktree_path,
+                new_worktree_path,
+            )
+            raise GitWorktreeMoveError(old_worktree_path, new_worktree_path)
+
+        self._logger.info("Successfully moved worktree to %s", new_worktree_path)
+        return new_worktree_path
+
+    async def lock_worktree(
+        self, path: str | Path, reason: str | None = None, timeout: int | None = None
+    ) -> None:
+        """Locks a Git worktree, preventing `git worktree prune` from removing it.
+
+        Corresponds to `git worktree lock <path> [--reason <reason>]`.
+
+        Args:
+            path: The path to the worktree to lock.
+            reason: An optional reason for locking the worktree.
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If the worktree lock operation fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+        worktree_path = Path(path).resolve()
+
+        cmd = ["worktree", "lock", str(worktree_path)]
+        if reason:
+            cmd.extend(["--reason", reason])
+
+        self._logger.info("Locking Git worktree at %s...", worktree_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)
+
+    async def unlock_worktree(
+        self, path: str | Path, timeout: int | None = None
+    ) -> None:
+        """Unlocks a Git worktree.
+
+        Corresponds to `git worktree unlock <path>`.
+
+        Args:
+            path: The path to the worktree to unlock.
+            timeout: Optional timeout for the operation.
+
+        Raises:
+            GitError: If the worktree unlock operation fails.
+        """
+        await self._check_is_git_repo(self.repo_path)
+        worktree_path = Path(path).resolve()
+
+        cmd = ["worktree", "unlock", str(worktree_path)]
+
+        self._logger.info("Unlocking Git worktree at %s...", worktree_path)
+        await self._run_git_cmd(cmd, cwd=self.repo_path, timeout=timeout)

--- a/tests/test_git_client.py
+++ b/tests/test_git_client.py
@@ -1,0 +1,1160 @@
+"""Pytest tests for the GitClient class in cloud-autopkg_runner.git_client."""
+
+import shutil
+from collections.abc import Generator
+from logging import Logger
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cloud_autopkg_runner import GitClient
+from cloud_autopkg_runner.exceptions import (
+    GitDefaultBranchError,
+    GitError,
+    GitMergeError,
+    GitRepoDoesNotExistError,
+    GitWorktreeCreationError,
+    GitWorktreeMissingPathError,
+    GitWorktreeMoveError,
+    PathNotGitRepoError,
+    ShellCommandException,
+)
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def mock_run_cmd() -> Generator[MagicMock | AsyncMock, Any, None]:
+    """Fixture to mock shell.run_cmd globally for tests using patch."""
+    with patch("cloud_autopkg_runner.shell.run_cmd", new_callable=AsyncMock) as _mock:
+        yield _mock
+
+
+@pytest.fixture
+def mock_logger() -> Generator[Logger, Any, None]:
+    """Fixture to mock the logger to prevent console output during tests."""
+    with patch("cloud_autopkg_runner.logging_config.get_logger") as mock_get_logger:
+        mock_logger_instance = mock_get_logger.return_value
+        mock_logger_instance.debug = MagicMock()
+        mock_logger_instance.info = MagicMock()
+        mock_logger_instance.warning = MagicMock()
+        mock_logger_instance.error = MagicMock()
+        mock_logger_instance.critical = MagicMock()
+        yield mock_logger_instance
+
+
+@pytest.fixture
+def tmp_repo_path(tmp_path: Path) -> Generator[Path, None]:
+    """Provides a temporary path for a Git repository, ensuring cleanup."""
+    repo_path = tmp_path / "test_repo"
+    repo_path.mkdir(exist_ok=True)
+    (repo_path / ".git").mkdir(exist_ok=True)
+    yield repo_path
+    if repo_path.exists():
+        shutil.rmtree(repo_path)
+
+
+# @pytest.fixture
+#     """Fixture to create a temporary directory structured like a Git repository."""
+#     repo_dir = tmp_path / "test_git_repo"
+#     repo_dir.mkdir()
+#     (repo_dir / ".git").mkdir()  # Simulate a .git directory
+#     return repo_dir
+
+
+@pytest.fixture
+def non_git_path(tmp_path: Path) -> Path:
+    """Fixture to create a temporary directory that is NOT a Git repository."""
+    non_git_dir = tmp_path / "non_git_dir"
+    non_git_dir.mkdir()
+    return non_git_dir
+
+
+@pytest.fixture
+def git_client_instance(tmp_repo_path: Path) -> GitClient:
+    """Fixture to provide an initialized GitClient instance for tests."""
+    return GitClient(tmp_repo_path)
+
+
+# --- Test __init__ ---
+
+
+@pytest.mark.asyncio
+async def test_init_success(tmp_repo_path: Path) -> None:
+    """Test GitClient initialization with a valid, existing path."""
+    client = GitClient(tmp_repo_path)
+    assert client.repo_path == tmp_repo_path.resolve()
+
+
+@pytest.mark.asyncio
+async def test_init_raises_git_repo_does_not_exist_error(tmp_path: Path) -> None:
+    """Test GitClient initialization with a non-existent path."""
+    non_existent_path = tmp_path / "non_existent_repo_xyz"
+    assert not non_existent_path.exists()  # Ensure it doesn't exist initially
+
+    with pytest.raises(GitRepoDoesNotExistError) as exc_info:
+        GitClient(non_existent_path)
+    assert str(non_existent_path) in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_init_raises_git_repo_does_not_exist_error_if_not_directory(
+    tmp_repo_path: Path,
+) -> None:
+    """Test GitClient initialization with a path to a file."""
+    test_file = tmp_repo_path / "test_file.txt"
+    test_file.touch()  # Create a file
+    # The current __init__ checks `is_dir()`. If it's a file, is_dir() is False,
+    # which leads to GitRepoDoesNotExistError.
+    with pytest.raises(GitRepoDoesNotExistError) as exc_info:
+        GitClient(test_file)
+    assert "Repository path does not exist:" in str(exc_info.value)
+
+
+# --- Test _run_git_cmd ---
+
+
+@pytest.mark.asyncio
+async def test_run_git_cmd_success(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test _run_git_cmd for successful execution."""
+    mock_run_cmd.return_value = (0, "stdout content", "stderr content")
+    returncode, stdout, stderr = await git_client_instance._run_git_cmd(["status"])
+    assert returncode == 0
+    assert stdout == "stdout content"
+    assert stderr == "stderr content"
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "status"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_git_cmd_raises_git_error_on_shell_command_exception(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test _run_git_cmd re-raises ShellCommandException as GitError."""
+    mock_run_cmd.side_effect = ShellCommandException("mock error")
+    with pytest.raises(GitError) as exc_info:
+        await git_client_instance._run_git_cmd(["status"])
+    assert "git status" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_run_git_cmd_raises_git_repo_does_not_exist_error_if_cwd_non_existent(
+    git_client_instance: GitClient, tmp_path: Path
+) -> None:
+    """Test _run_git_cmd raises GitRepoDoesNotExistError if cwd is non-existent."""
+    non_existent_cwd = tmp_path / "non_existent_cwd_for_git_cmd"
+    assert not non_existent_cwd.exists()
+
+    with pytest.raises(GitRepoDoesNotExistError) as exc_info:
+        await git_client_instance._run_git_cmd(["status"], cwd=non_existent_cwd)
+    assert str(non_existent_cwd) in str(exc_info.value)
+
+
+# --- Test _check_is_git_repo ---
+
+
+@pytest.mark.asyncio
+async def test_check_is_git_repo_success(git_client_instance: GitClient) -> None:
+    """Test _check_is_git_repo with a valid Git repository."""
+    # No exception should be raised. The fixture provides a valid repo.
+    await git_client_instance._check_is_git_repo(git_client_instance.repo_path)
+
+
+@pytest.mark.asyncio
+async def test_check_is_git_repo_raises_git_repo_does_not_exist_error(
+    git_client_instance: GitClient, tmp_path: Path
+) -> None:
+    """Test _check_is_git_repo with a non-existent path."""
+    non_existent_path = tmp_path / "non_existent_check_repo_xyz"
+    assert not non_existent_path.exists()
+
+    with pytest.raises(GitRepoDoesNotExistError) as exc_info:
+        await git_client_instance._check_is_git_repo(non_existent_path)
+    assert str(non_existent_path) in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_check_is_git_repo_raises_path_not_git_repo_error(
+    git_client_instance: GitClient,
+) -> None:
+    """Test _check_is_git_repo with an existing path that is not a Git repo."""
+    # Remove the mock .git directory to simulate a non-Git repo
+    (git_client_instance.repo_path / ".git").rmdir()
+    with pytest.raises(PathNotGitRepoError) as exc_info:
+        await git_client_instance._check_is_git_repo(git_client_instance.repo_path)
+    assert "not appear to be a Git repository" in str(exc_info.value)
+
+
+# --- Test init ---
+
+
+@pytest.mark.asyncio
+async def test_init_creates_repo(
+    tmp_path: Path, mock_run_cmd: AsyncMock, mock_logger: Logger
+) -> None:
+    """Test init command successfully initializes a new repository."""
+    new_repo_path = tmp_path / "new_git_repo_for_init_test"
+    if new_repo_path.exists():
+        new_repo_path.unlink()
+    assert not new_repo_path.exists()
+
+    # To instantiate GitClient, new_repo_path must be a directory.
+    # So we create the physical directory first for __init__ to pass.
+    new_repo_path.mkdir(parents=True, exist_ok=True)
+
+    client = GitClient(new_repo_path)
+
+    # In this scenario, `client.repo_path.exists()` will return True naturally.
+    # So `client.repo_path.mkdir()` should NOT be called by the init method.
+    mock_run_cmd.return_value = (0, "", "")
+
+    await client.init(initial_branch="main")
+
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "init", "-b", "main"],
+        cwd=str(new_repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+    mock_logger.info.assert_called_with(
+        "Initializing Git repository at %s...", new_repo_path
+    )
+
+
+@pytest.mark.asyncio
+async def test_init_with_bare(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test init command with bare option."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.init(bare=True)
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "init", "--bare"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test add ---
+
+
+@pytest.mark.asyncio
+async def test_add_single_file(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test add command with a single file."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.add("file.txt")
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "add", "file.txt"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_multiple_files(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test add command with multiple files and options."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.add(["file1.txt", "file2.txt"], force=True, update=True)
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "add", "--force", "--update", "file1.txt", "file2.txt"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test commit ---
+
+
+@pytest.mark.asyncio
+async def test_commit_basic(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test commit command with a basic message."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.commit("Initial commit")
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "commit", "-m", "Initial commit"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_commit_with_all_options(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test commit command with all optional arguments."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.commit(
+        "Test commit",
+        allow_empty=True,
+        all_changes=True,
+        no_verify=True,
+        amend=True,
+        author="Test Author <test@example.com>",
+    )
+    mock_run_cmd.assert_awaited_once_with(
+        [
+            "git",
+            "commit",
+            "-m",
+            "Test commit",
+            "--allow-empty",
+            "--all",
+            "--no-verify",
+            "--amend",
+            "--author=Test Author <test@example.com>",
+        ],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test branch ---
+
+
+@pytest.mark.asyncio
+async def test_branch_create(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test branch command to create a new branch."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.branch("new-feature")
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "branch", "new-feature"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_branch_create_from_start_point(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test branch command to create a branch from a specific start point."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.branch("hotfix", start_point="main")
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "branch", "hotfix", "main"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_branch_create_force(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test branch command with force option."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.branch("existing-branch", force=True)
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "branch", "--force", "existing-branch"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test merge_branch ---
+
+
+@pytest.mark.asyncio
+async def test_merge_branch_success(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test merge_branch successfully merges a branch."""
+    mock_run_cmd.side_effect = [
+        (0, "main\n", ""),  # For get_current_branch: 'main'
+        (0, "", ""),  # For merge command
+    ]
+    await git_client_instance.merge_branch("feature-x", target_branch="main")
+    mock_run_cmd.assert_any_call(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+    mock_run_cmd.assert_called_with(
+        ["git", "merge", "feature-x"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_branch_raises_git_merge_error_if_target_not_checked_out(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test merge_branch raises GitMergeError if target branch is not current."""
+    mock_run_cmd.return_value = (0, "dev\n", "")  # current branch is 'dev'
+    with pytest.raises(GitMergeError) as exc_info:
+        await git_client_instance.merge_branch("feature-x", target_branch="main")
+    assert (
+        "Cannot merge: 'main' is not currently checked out. Current branch is 'dev'."
+        in str(exc_info.value)
+    )
+    mock_run_cmd.assert_awaited_once_with(  # Assert that get_current_branch was called
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_branch_with_no_ff_and_no_edit(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test merge_branch with --no-ff and --no-edit options."""
+    mock_run_cmd.side_effect = [
+        (0, "main\n", ""),  # For get_current_branch
+        (0, "", ""),  # For merge command
+    ]
+    await git_client_instance.merge_branch(
+        "feature-y", target_branch="main", no_ff=True, no_edit=True
+    )
+    mock_run_cmd.assert_called_with(
+        ["git", "merge", "--no-ff", "--no-edit", "feature-y"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_branch_with_squash(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test merge_branch with --squash option."""
+    mock_run_cmd.side_effect = [
+        (0, "main\n", ""),  # For get_current_branch
+        (0, "", ""),  # For merge command
+    ]
+    await git_client_instance.merge_branch(
+        "feature-z", target_branch="main", squash=True
+    )
+    mock_run_cmd.assert_called_with(
+        ["git", "merge", "--squash", "feature-z"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_branch_target_is_head(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test merge_branch when target_branch is 'HEAD' (no current branch check)."""
+    mock_run_cmd.return_value = (0, "", "")  # Only for the merge command
+    await git_client_instance.merge_branch("another-feature", target_branch="HEAD")
+    # No call to get_current_branch should happen
+    mock_run_cmd.assert_called_once_with(
+        ["git", "merge", "another-feature"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test checkout ---
+
+
+@pytest.mark.asyncio
+async def test_checkout_branch(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test checkout command to switch to an existing branch."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.checkout("existing-branch")
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "checkout", "existing-branch"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_checkout_new_branch(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test checkout command to create and switch to a new branch."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.checkout("new-branch-checkout", create_branch=True)
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "checkout", "-b", "new-branch-checkout"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test fetch ---
+
+
+@pytest.mark.asyncio
+async def test_fetch_default(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test fetch command without specific remote."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.fetch()
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "fetch"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_options(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test fetch command with remote and various options."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.fetch("origin", prune=True, all_remotes=True, tags=True)
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "fetch", "--prune", "--all", "--tags", "origin"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test pull ---
+
+
+@pytest.mark.asyncio
+async def test_pull_default(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test pull command without specific remote/branch."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.pull()
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "pull"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_with_rebase(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test pull command with rebase option."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.pull("origin", "main", rebase=True)
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "pull", "--rebase", "origin", "main"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test push ---
+
+
+@pytest.mark.asyncio
+async def test_push_default(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test push command without specific remote/branch."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.push()
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "push"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_push_with_force_and_set_upstream(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test push command with force and set_upstream options."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.push(
+        "origin", "feature-branch", force=True, set_upstream=True
+    )
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "push", "--force", "--set-upstream", "origin", "feature-branch"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test status ---
+
+
+@pytest.mark.asyncio
+async def test_status_default(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test status command returns expected output."""
+    expected_output = "M README.md"
+    mock_run_cmd.return_value = (0, expected_output, "")
+    status = await git_client_instance.status()
+    assert status == expected_output
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "status"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_status_porcelain(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test status command with porcelain option."""
+    expected_output = " M README.md"
+    mock_run_cmd.return_value = (0, expected_output, "")
+    status = await git_client_instance.status(porcelain=True)
+    assert status == expected_output
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "status", "--porcelain"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test get_current_branch ---
+
+
+@pytest.mark.asyncio
+async def test_get_current_branch_success(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test get_current_branch returns the correct branch name."""
+    mock_run_cmd.return_value = (0, "main\n", "")
+    branch = await git_client_instance.get_current_branch()
+    assert branch == "main"
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_current_branch_error(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test get_current_branch raises GitError on underlying failure."""
+    mock_run_cmd.side_effect = ShellCommandException("mock error")
+    with pytest.raises(GitError):
+        await git_client_instance.get_current_branch()
+
+
+# --- Test get_default_branch ---
+
+
+@pytest.mark.asyncio
+async def test_get_default_branch_success_main(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test get_default_branch correctly identifies 'main' as default."""
+    mock_output = """* remote origin
+  Fetch URL: git@github.com:user/repo.git
+  Push  URL: git@github.com:user/repo.git
+  HEAD branch: main
+  Remote branches:
+    main tracked
+    feature tracked
+  Local branch configured for 'git pull':
+    main merges with remote main
+  Local ref configured for 'git push':
+    main pushes to remote main (up to date)
+"""
+    mock_run_cmd.return_value = (0, mock_output, "")
+    default_branch = await git_client_instance.get_default_branch("origin")
+    assert default_branch == "main"
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "remote", "show", "origin"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_default_branch_success_master(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test get_default_branch correctly identifies 'master' as default."""
+    mock_output = """* remote upstream
+  Fetch URL: https://github.com/another/repo.git
+  Push  URL: https://github.com/another/repo.git
+  HEAD branch: master
+"""
+    mock_run_cmd.return_value = (0, mock_output, "")
+    default_branch = await git_client_instance.get_default_branch("upstream")
+    assert default_branch == "master"
+
+
+@pytest.mark.asyncio
+async def test_get_default_branch_raises_git_default_branch_error_no_head_branch_line(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test get_default_branch raises error if 'HEAD branch' line is missing."""
+    mock_output = """* remote origin
+  Fetch URL: git@github.com:user/repo.git
+"""
+    mock_run_cmd.return_value = (0, mock_output, "")
+    with pytest.raises(GitDefaultBranchError) as exc_info:
+        await git_client_instance.get_default_branch("origin")
+    assert "Could not determine default branch for remote 'origin'" in str(
+        exc_info.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_default_branch_raises_git_error_on_underlying_failure(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test get_default_branch raises GitError on underlying shell failure."""
+    mock_run_cmd.side_effect = ShellCommandException("remote not found")
+    with pytest.raises(GitError):
+        await git_client_instance.get_default_branch("nonexistent")
+
+
+# --- Test get_remote_url ---
+
+
+@pytest.mark.asyncio
+async def test_get_remote_url_success(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test get_remote_url returns the correct URL."""
+    mock_run_cmd.return_value = (0, "https://github.com/user/repo.git\n", "")
+    url = await git_client_instance.get_remote_url("origin")
+    assert url == "https://github.com/user/repo.git"
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "remote", "get-url", "origin"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test add_remote ---
+
+
+@pytest.mark.asyncio
+async def test_add_remote_success(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test add_remote command successfully adds a remote."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.add_remote(
+        "upstream", "https://github.com/upstream/repo.git"
+    )
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "remote", "add", "upstream", "https://github.com/upstream/repo.git"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_remote_with_track_branches(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test add_remote command with track_branches option."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.add_remote(
+        "myremote", "ssh://git@host/path.git", track_branches=["dev", "prod"]
+    )
+    mock_run_cmd.assert_awaited_once_with(
+        [
+            "git",
+            "remote",
+            "add",
+            "-t",
+            "dev",
+            "-t",
+            "prod",
+            "myremote",
+            "ssh://git@host/path.git",
+        ],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test add_worktree ---
+
+
+@pytest.mark.asyncio
+async def test_add_worktree_success(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_repo_path: Path
+) -> None:
+    """Test add_worktree successfully creates a worktree."""
+    mock_run_cmd.return_value = (0, "", "")
+
+    created_path = await git_client_instance.add_worktree(
+        tmp_repo_path, "feature-branch"
+    )
+
+    assert created_path == tmp_repo_path.resolve()
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "worktree", "add", str(tmp_repo_path), "feature-branch"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_worktree_raises_creation_error_on_git_failure(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_path: Path
+) -> None:
+    """Test add_worktree raises GitWorktreeCreationError on underlying Git failure."""
+    worktree_path = tmp_path / "worktree_fail"
+    mock_run_cmd.side_effect = ShellCommandException("git worktree add failed")
+
+    with pytest.raises(GitWorktreeCreationError) as exc_info:
+        await git_client_instance.add_worktree(worktree_path, "branch")
+    assert f"Failed to create worktree at {worktree_path}" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_add_worktree_raises_creation_error_on_verification_failure(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_path: Path
+) -> None:
+    """Test add_worktree raises GitWorktreeCreationError if worktree not verified."""
+    worktree_path = tmp_path / "worktree_no_verify"
+
+    mock_run_cmd.return_value = (0, "", "")  # Git command itself succeeds
+
+    with pytest.raises(GitWorktreeCreationError) as exc_info:
+        await git_client_instance.add_worktree(worktree_path, "branch")
+    assert f"Failed to create worktree at {worktree_path}" in str(exc_info.value)
+
+
+# --- Test list_worktrees ---
+
+
+@pytest.mark.asyncio
+async def test_list_worktrees_success_multiple(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test list_worktrees correctly parses multiple worktrees."""
+    mock_output = """worktree /path/to/repo
+HEAD abcd1234abcd1234abcd1234abcd1234abcd1234
+branch refs/heads/main
+worktree /path/to/worktree1
+HEAD efgh5678efgh5678efgh5678efgh5678efgh5678
+branch refs/heads/feature/branch-x
+worktree /path/to/worktree2
+HEAD 1234abcd1234abcd1234abcd1234abcd1234abcd
+"""
+    mock_run_cmd.return_value = (0, mock_output, "")
+    worktrees = await git_client_instance.list_worktrees()
+    assert len(worktrees) == 3
+    # Use .resolve() on the expected paths too for consistent comparison
+    assert worktrees[0] == (Path("/path/to/repo").resolve(), "main")
+    assert worktrees[1] == (Path("/path/to/worktree1").resolve(), "feature/branch-x")
+    assert worktrees[2] == (
+        Path("/path/to/worktree2").resolve(),
+        "1234abcd1234abcd1234abcd1234abcd1234abcd",
+    )
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_worktrees_success_empty(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test list_worktrees returns empty list for no worktrees."""
+    mock_run_cmd.return_value = (0, "", "")  # Empty output
+    worktrees = await git_client_instance.list_worktrees()
+    assert len(worktrees) == 0
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test remove_worktree ---
+
+
+@pytest.mark.asyncio
+async def test_remove_worktree_success(
+    git_client_instance: GitClient,
+    mock_run_cmd: AsyncMock,
+    mock_logger: Logger,
+    tmp_path: Path,
+) -> None:
+    """Test remove_worktree successfully removes a worktree."""
+    worktree_path = tmp_path / "worktree_to_remove"
+    worktree_path.mkdir(exist_ok=True)
+
+    mock_run_cmd.return_value = (0, "", "")  # Git command succeeds
+
+    await git_client_instance.remove_worktree(worktree_path)
+
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "worktree", "remove", str(worktree_path)],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+    mock_logger.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_remove_worktree_with_force(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_path: Path
+) -> None:
+    """Test remove_worktree with force option."""
+    worktree_path = tmp_path / "worktree_to_remove_force"
+    worktree_path.mkdir(exist_ok=True)
+
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.remove_worktree(worktree_path, force=True)
+
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "worktree", "remove", "--force", str(worktree_path)],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_worktree_warns_if_dir_remains(
+    git_client_instance: GitClient,
+    mock_run_cmd: AsyncMock,
+    tmp_path: Path,
+) -> None:
+    """Test remove_worktree warns if directory still exists after command."""
+    worktree_path = tmp_path / "worktree_remains"
+    worktree_path.mkdir(exist_ok=True)
+    mock_run_cmd.return_value = (0, "", "")
+
+    await git_client_instance.remove_worktree(worktree_path)
+    assert worktree_path.exists()
+
+
+# --- Test prune_worktrees ---
+
+
+@pytest.mark.asyncio
+async def test_prune_worktrees_success(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock
+) -> None:
+    """Test prune_worktrees command successfully."""
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.prune_worktrees()
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "worktree", "prune"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test move_worktree ---
+
+
+@pytest.mark.asyncio
+async def test_move_worktree_raises_missing_path_error_if_old_path_non_existent(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_path: Path
+) -> None:
+    """Test move_worktree raises error if old path doesn't exist."""
+    old_path = tmp_path / "non_existent_old"
+    new_path = tmp_path / "new"
+    # Do not create old_path, so its .is_dir() will return False naturally.
+    assert not old_path.is_dir()
+
+    with pytest.raises(GitWorktreeMissingPathError) as exc_info:
+        await git_client_instance.move_worktree(old_path, new_path)
+    assert f"Worktree directory does not exist: {old_path}" in str(exc_info.value)
+    mock_run_cmd.assert_not_awaited()  # Git command should not be called
+
+
+@pytest.mark.asyncio
+async def test_move_worktree_raises_move_error_on_git_failure(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_path: Path
+) -> None:
+    """Test move_worktree raises GitWorktreeMoveError on underlying Git failure."""
+    old_path = tmp_path / "old"
+    new_path = tmp_path / "new"
+    old_path.mkdir(
+        parents=True, exist_ok=True
+    )  # Ensure old_path exists for is_dir check
+
+    mock_run_cmd.side_effect = ShellCommandException(
+        "git move failed"
+    )  # Simulate Git command failure
+
+    with pytest.raises(GitWorktreeMoveError) as exc_info:
+        await git_client_instance.move_worktree(old_path, new_path)
+    assert f"Failed to move worktree from {old_path} to {new_path}" in str(
+        exc_info.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_move_worktree_raises_move_error_on_verification_failure(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_path: Path
+) -> None:
+    """Test move_worktree raises error if verification fails after move."""
+    old_path = tmp_path / "old_no_verify"
+    new_path = tmp_path / "new_no_verify"
+    old_path.mkdir(parents=True, exist_ok=True)
+
+    mock_run_cmd.return_value = (0, "", "")
+
+    with pytest.raises(GitWorktreeMoveError) as exc_info:
+        await git_client_instance.move_worktree(old_path, new_path)
+
+    assert f"Failed to move worktree from {old_path} to {new_path}" in str(
+        exc_info.value
+    )
+    assert old_path.exists()
+    assert not new_path.exists()
+
+
+# --- Test lock_worktree ---
+
+
+@pytest.mark.asyncio
+async def test_lock_worktree_success(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_path: Path
+) -> None:
+    """Test lock_worktree successfully locks a worktree."""
+    worktree_path = tmp_path / "locked_worktree"  # Use tmp_path for consistency
+    worktree_path.mkdir(
+        exist_ok=True
+    )  # Ensure this path exists and is a directory for validation
+
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.lock_worktree(worktree_path)
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "worktree", "lock", str(worktree_path)],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_worktree_with_reason(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_path: Path
+) -> None:
+    """Test lock_worktree with a reason."""
+    worktree_path = tmp_path / "locked_worktree_reason"
+    worktree_path.mkdir(exist_ok=True)
+
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.lock_worktree(worktree_path, reason="Important work")
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "worktree", "lock", str(worktree_path), "--reason", "Important work"],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+# --- Test unlock_worktree ---
+
+
+@pytest.mark.asyncio
+async def test_unlock_worktree_success(
+    git_client_instance: GitClient, mock_run_cmd: AsyncMock, tmp_path: Path
+) -> None:
+    """Test unlock_worktree successfully unlocks a worktree."""
+    worktree_path = tmp_path / "unlocked_worktree"
+    worktree_path.mkdir(exist_ok=True)
+
+    mock_run_cmd.return_value = (0, "", "")
+    await git_client_instance.unlock_worktree(worktree_path)
+    mock_run_cmd.assert_awaited_once_with(
+        ["git", "worktree", "unlock", str(worktree_path)],
+        cwd=str(git_client_instance.repo_path),
+        check=True,
+        capture_output=True,
+        timeout=None,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -169,21 +169,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anyio"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
-]
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -253,15 +238,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
-]
-
-[[package]]
-name = "backports-tarfile"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
 ]
 
 [[package]]
@@ -450,18 +426,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
-]
-
-[[package]]
 name = "cloud-autopkg-runner"
 version = "0.16.1"
 source = { editable = "." }
@@ -484,7 +448,6 @@ s3 = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "hatch" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest-asyncio" },
@@ -506,12 +469,11 @@ provides-extras = ["azure", "gcs", "json", "s3", "sqlite"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "hatch", specifier = ">=1.14.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pyright", specifier = ">=1.1.397" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "ruff", specifier = ">=0.11.0" },
+    { name = "ruff", specifier = ">=0.12.7" },
     { name = "types-aioboto3-lite", extras = ["s3"], specifier = ">=1.38.10" },
 ]
 
@@ -905,98 +867,6 @@ wheels = [
 ]
 
 [[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "hatch"
-version = "1.14.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "hatchling" },
-    { name = "httpx" },
-    { name = "hyperlink" },
-    { name = "keyring" },
-    { name = "packaging" },
-    { name = "pexpect" },
-    { name = "platformdirs" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "tomli-w" },
-    { name = "tomlkit" },
-    { name = "userpath" },
-    { name = "uv" },
-    { name = "virtualenv" },
-    { name = "zstandard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/43/c0b37db0e857a44ce5ffdb7e8a9b8fa6425d0b74dea698fafcd9bddb50d1/hatch-1.14.1.tar.gz", hash = "sha256:ca1aff788f8596b0dd1f8f8dfe776443d2724a86b1976fabaf087406ba3d0713", size = 5188180, upload-time = "2025-04-07T04:16:04.522Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/40/19c0935bf9f25808541a0e3144ac459de696c5b6b6d4511a98d456c69604/hatch-1.14.1-py3-none-any.whl", hash = "sha256:39cdaa59e47ce0c5505d88a951f4324a9c5aafa17e4a877e2fde79b36ab66c21", size = 125770, upload-time = "2025-04-07T04:16:02.525Z" },
-]
-
-[[package]]
-name = "hatchling"
-version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pluggy" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "trove-classifiers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983, upload-time = "2024-12-15T17:08:11.894Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794, upload-time = "2024-12-15T17:08:10.364Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "hyperlink"
-version = "21.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
-]
-
-[[package]]
 name = "identify"
 version = "2.6.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1012,18 +882,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
 ]
 
 [[package]]
@@ -1045,105 +903,12 @@ wheels = [
 ]
 
 [[package]]
-name = "jaraco-classes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
-]
-
-[[package]]
-name = "jaraco-context"
-version = "6.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload-time = "2024-08-20T03:39:27.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825, upload-time = "2024-08-20T03:39:25.966Z" },
-]
-
-[[package]]
-name = "jaraco-functools"
-version = "4.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/1c/831faaaa0f090b711c355c6d8b2abf277c72133aab472b6932b03322294c/jaraco_functools-4.2.1.tar.gz", hash = "sha256:be634abfccabce56fa3053f8c7ebe37b682683a4ee7793670ced17bab0087353", size = 19661, upload-time = "2025-06-21T19:22:03.201Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/fd/179a20f832824514df39a90bb0e5372b314fea99f217f5ab942b10a8a4e8/jaraco_functools-4.2.1-py3-none-any.whl", hash = "sha256:590486285803805f4b1f99c60ca9e94ed348d4added84b74c7a12885561e524e", size = 10349, upload-time = "2025-06-21T19:22:02.039Z" },
-]
-
-[[package]]
-name = "jeepney"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
-]
-
-[[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
-]
-
-[[package]]
-name = "keyring"
-version = "25.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
-    { name = "jaraco-classes" },
-    { name = "jaraco-context" },
-    { name = "jaraco-functools" },
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750, upload-time = "2024-12-25T15:26:45.782Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl", hash = "sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd", size = 39085, upload-time = "2024-12-25T15:26:44.377Z" },
-]
-
-[[package]]
-name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "more-itertools"
-version = "10.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671, upload-time = "2025-04-22T14:17:41.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278, upload-time = "2025-04-22T14:17:40.49Z" },
 ]
 
 [[package]]
@@ -1290,27 +1055,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
-name = "pexpect"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ptyprocess" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
 ]
 
 [[package]]
@@ -1463,15 +1207,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ptyprocess"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
-]
-
-[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1595,15 +1330,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pywin32-ctypes"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1663,19 +1389,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "14.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
-]
-
-[[package]]
 name = "rsa"
 version = "4.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1689,27 +1402,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.12.5"
+version = "0.12.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/cd/01015eb5034605fd98d829c5839ec2c6b4582b479707f7c1c2af861e8258/ruff-0.12.5.tar.gz", hash = "sha256:b209db6102b66f13625940b7f8c7d0f18e20039bb7f6101fbdac935c9612057e", size = 5170722, upload-time = "2025-07-24T13:26:37.456Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/da/5bd7565be729e86e1442dad2c9a364ceeff82227c2dece7c29697a9795eb/ruff-0.12.8.tar.gz", hash = "sha256:4cb3a45525176e1009b2b64126acf5f9444ea59066262791febf55e40493a033", size = 5242373, upload-time = "2025-08-07T19:05:47.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/de/ad2f68f0798ff15dd8c0bcc2889558970d9a685b3249565a937cd820ad34/ruff-0.12.5-py3-none-linux_armv6l.whl", hash = "sha256:1de2c887e9dec6cb31fcb9948299de5b2db38144e66403b9660c9548a67abd92", size = 11819133, upload-time = "2025-07-24T13:25:56.369Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/fc/c6b65cd0e7fbe60f17e7ad619dca796aa49fbca34bb9bea5f8faf1ec2643/ruff-0.12.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d1ab65e7d8152f519e7dea4de892317c9da7a108da1c56b6a3c1d5e7cf4c5e9a", size = 12501114, upload-time = "2025-07-24T13:25:59.471Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/de/c6bec1dce5ead9f9e6a946ea15e8d698c35f19edc508289d70a577921b30/ruff-0.12.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:962775ed5b27c7aa3fdc0d8f4d4433deae7659ef99ea20f783d666e77338b8cf", size = 11716873, upload-time = "2025-07-24T13:26:01.496Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/16/cf372d2ebe91e4eb5b82a2275c3acfa879e0566a7ac94d331ea37b765ac8/ruff-0.12.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:73b4cae449597e7195a49eb1cdca89fd9fbb16140c7579899e87f4c85bf82f73", size = 11958829, upload-time = "2025-07-24T13:26:03.721Z" },
-    { url = "https://files.pythonhosted.org/packages/25/bf/cd07e8f6a3a6ec746c62556b4c4b79eeb9b0328b362bb8431b7b8afd3856/ruff-0.12.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b13489c3dc50de5e2d40110c0cce371e00186b880842e245186ca862bf9a1ac", size = 11626619, upload-time = "2025-07-24T13:26:06.118Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/c9/c2ccb3b8cbb5661ffda6925f81a13edbb786e623876141b04919d1128370/ruff-0.12.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f1504fea81461cf4841778b3ef0a078757602a3b3ea4b008feb1308cb3f23e08", size = 13221894, upload-time = "2025-07-24T13:26:08.292Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/58/68a5be2c8e5590ecdad922b2bcd5583af19ba648f7648f95c51c3c1eca81/ruff-0.12.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c7da4129016ae26c32dfcbd5b671fe652b5ab7fc40095d80dcff78175e7eddd4", size = 14163909, upload-time = "2025-07-24T13:26:10.474Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/d1/ef6b19622009ba8386fdb792c0743f709cf917b0b2f1400589cbe4739a33/ruff-0.12.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ca972c80f7ebcfd8af75a0f18b17c42d9f1ef203d163669150453f50ca98ab7b", size = 13583652, upload-time = "2025-07-24T13:26:13.381Z" },
-    { url = "https://files.pythonhosted.org/packages/62/e3/1c98c566fe6809a0c83751d825a03727f242cdbe0d142c9e292725585521/ruff-0.12.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8dbbf9f25dfb501f4237ae7501d6364b76a01341c6f1b2cd6764fe449124bb2a", size = 12700451, upload-time = "2025-07-24T13:26:15.488Z" },
-    { url = "https://files.pythonhosted.org/packages/24/ff/96058f6506aac0fbc0d0fc0d60b0d0bd746240a0594657a2d94ad28033ba/ruff-0.12.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c47dea6ae39421851685141ba9734767f960113d51e83fd7bb9958d5be8763a", size = 12937465, upload-time = "2025-07-24T13:26:17.808Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d3/68bc5e7ab96c94b3589d1789f2dd6dd4b27b263310019529ac9be1e8f31b/ruff-0.12.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c5076aa0e61e30f848846f0265c873c249d4b558105b221be1828f9f79903dc5", size = 11771136, upload-time = "2025-07-24T13:26:20.422Z" },
-    { url = "https://files.pythonhosted.org/packages/52/75/7356af30a14584981cabfefcf6106dea98cec9a7af4acb5daaf4b114845f/ruff-0.12.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a5a4c7830dadd3d8c39b1cc85386e2c1e62344f20766be6f173c22fb5f72f293", size = 11601644, upload-time = "2025-07-24T13:26:22.928Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/67/91c71d27205871737cae11025ee2b098f512104e26ffd8656fd93d0ada0a/ruff-0.12.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:46699f73c2b5b137b9dc0fc1a190b43e35b008b398c6066ea1350cce6326adcb", size = 12478068, upload-time = "2025-07-24T13:26:26.134Z" },
-    { url = "https://files.pythonhosted.org/packages/34/04/b6b00383cf2f48e8e78e14eb258942fdf2a9bf0287fbf5cdd398b749193a/ruff-0.12.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5a655a0a0d396f0f072faafc18ebd59adde8ca85fb848dc1b0d9f024b9c4d3bb", size = 12991537, upload-time = "2025-07-24T13:26:28.533Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/b9/053d6445dc7544fb6594785056d8ece61daae7214859ada4a152ad56b6e0/ruff-0.12.5-py3-none-win32.whl", hash = "sha256:dfeb2627c459b0b78ca2bbdc38dd11cc9a0a88bf91db982058b26ce41714ffa9", size = 11751575, upload-time = "2025-07-24T13:26:30.835Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/0f/ab16e8259493137598b9149734fec2e06fdeda9837e6f634f5c4e35916da/ruff-0.12.5-py3-none-win_amd64.whl", hash = "sha256:ae0d90cf5f49466c954991b9d8b953bd093c32c27608e409ae3564c63c5306a5", size = 12882273, upload-time = "2025-07-24T13:26:32.929Z" },
-    { url = "https://files.pythonhosted.org/packages/00/db/c376b0661c24cf770cb8815268190668ec1330eba8374a126ceef8c72d55/ruff-0.12.5-py3-none-win_arm64.whl", hash = "sha256:48cdbfc633de2c5c37d9f090ba3b352d1576b0015bfc3bc98eaf230275b7e805", size = 11951564, upload-time = "2025-07-24T13:26:34.994Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1e/c843bfa8ad1114fab3eb2b78235dda76acd66384c663a4e0415ecc13aa1e/ruff-0.12.8-py3-none-linux_armv6l.whl", hash = "sha256:63cb5a5e933fc913e5823a0dfdc3c99add73f52d139d6cd5cc8639d0e0465513", size = 11675315, upload-time = "2025-08-07T19:05:06.15Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ee/af6e5c2a8ca3a81676d5480a1025494fd104b8896266502bb4de2a0e8388/ruff-0.12.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a9bbe28f9f551accf84a24c366c1aa8774d6748438b47174f8e8565ab9dedbc", size = 12456653, upload-time = "2025-08-07T19:05:09.759Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9d/e91f84dfe3866fa648c10512904991ecc326fd0b66578b324ee6ecb8f725/ruff-0.12.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2fae54e752a3150f7ee0e09bce2e133caf10ce9d971510a9b925392dc98d2fec", size = 11659690, upload-time = "2025-08-07T19:05:12.551Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ac/a363d25ec53040408ebdd4efcee929d48547665858ede0505d1d8041b2e5/ruff-0.12.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0acbcf01206df963d9331b5838fb31f3b44fa979ee7fa368b9b9057d89f4a53", size = 11896923, upload-time = "2025-08-07T19:05:14.821Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9f/ea356cd87c395f6ade9bb81365bd909ff60860975ca1bc39f0e59de3da37/ruff-0.12.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ae3e7504666ad4c62f9ac8eedb52a93f9ebdeb34742b8b71cd3cccd24912719f", size = 11477612, upload-time = "2025-08-07T19:05:16.712Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/46/92e8fa3c9dcfd49175225c09053916cb97bb7204f9f899c2f2baca69e450/ruff-0.12.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb82efb5d35d07497813a1c5647867390a7d83304562607f3579602fa3d7d46f", size = 13182745, upload-time = "2025-08-07T19:05:18.709Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c4/f2176a310f26e6160deaf661ef60db6c3bb62b7a35e57ae28f27a09a7d63/ruff-0.12.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:dbea798fc0065ad0b84a2947b0aff4233f0cb30f226f00a2c5850ca4393de609", size = 14206885, upload-time = "2025-08-07T19:05:21.025Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9d/98e162f3eeeb6689acbedbae5050b4b3220754554526c50c292b611d3a63/ruff-0.12.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:49ebcaccc2bdad86fd51b7864e3d808aad404aab8df33d469b6e65584656263a", size = 13639381, upload-time = "2025-08-07T19:05:23.423Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4e/1b7478b072fcde5161b48f64774d6edd59d6d198e4ba8918d9f4702b8043/ruff-0.12.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ac9c570634b98c71c88cb17badd90f13fc076a472ba6ef1d113d8ed3df109fb", size = 12613271, upload-time = "2025-08-07T19:05:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/67/0c3c9179a3ad19791ef1b8f7138aa27d4578c78700551c60d9260b2c660d/ruff-0.12.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:560e0cd641e45591a3e42cb50ef61ce07162b9c233786663fdce2d8557d99818", size = 12847783, upload-time = "2025-08-07T19:05:28.14Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2a/0b6ac3dd045acf8aa229b12c9c17bb35508191b71a14904baf99573a21bd/ruff-0.12.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:71c83121512e7743fba5a8848c261dcc454cafb3ef2934a43f1b7a4eb5a447ea", size = 11702672, upload-time = "2025-08-07T19:05:30.413Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ee/f9fdc9f341b0430110de8b39a6ee5fa68c5706dc7c0aa940817947d6937e/ruff-0.12.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:de4429ef2ba091ecddedd300f4c3f24bca875d3d8b23340728c3cb0da81072c3", size = 11440626, upload-time = "2025-08-07T19:05:32.492Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/b3aa2d482d05f44e4d197d1de5e3863feb13067b22c571b9561085c999dc/ruff-0.12.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a2cab5f60d5b65b50fba39a8950c8746df1627d54ba1197f970763917184b161", size = 12462162, upload-time = "2025-08-07T19:05:34.449Z" },
+    { url = "https://files.pythonhosted.org/packages/18/9f/5c5d93e1d00d854d5013c96e1a92c33b703a0332707a7cdbd0a4880a84fb/ruff-0.12.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:45c32487e14f60b88aad6be9fd5da5093dbefb0e3e1224131cb1d441d7cb7d46", size = 12913212, upload-time = "2025-08-07T19:05:36.541Z" },
+    { url = "https://files.pythonhosted.org/packages/71/13/ab9120add1c0e4604c71bfc2e4ef7d63bebece0cfe617013da289539cef8/ruff-0.12.8-py3-none-win32.whl", hash = "sha256:daf3475060a617fd5bc80638aeaf2f5937f10af3ec44464e280a9d2218e720d3", size = 11694382, upload-time = "2025-08-07T19:05:38.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/dc/a2873b7c5001c62f46266685863bee2888caf469d1edac84bf3242074be2/ruff-0.12.8-py3-none-win_amd64.whl", hash = "sha256:7209531f1a1fcfbe8e46bcd7ab30e2f43604d8ba1c49029bb420b103d0b5f76e", size = 12740482, upload-time = "2025-08-07T19:05:40.391Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5c/799a1efb8b5abab56e8a9f2a0b72d12bd64bb55815e9476c7d0a2887d2f7/ruff-0.12.8-py3-none-win_arm64.whl", hash = "sha256:c90e1a334683ce41b0e7a04f41790c429bf5073b62c1ae701c9dc5b3d14f0749", size = 11884718, upload-time = "2025-08-07T19:05:42.866Z" },
 ]
 
 [[package]]
@@ -1725,43 +1438,12 @@ wheels = [
 ]
 
 [[package]]
-name = "secretstorage"
-version = "3.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221, upload-time = "2022-08-13T16:22:44.457Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -1801,33 +1483,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
-]
-
-[[package]]
-name = "tomli-w"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.13.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
-]
-
-[[package]]
-name = "trove-classifiers"
-version = "2025.5.9.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/38/04/1cd43f72c241fedcf0d9a18d0783953ee301eac9e5d9db1df0f0f089d9af/trove_classifiers-2025.5.9.12.tar.gz", hash = "sha256:7ca7c8a7a76e2cd314468c677c69d12cc2357711fcab4a60f87994c1589e5cb5", size = 16940, upload-time = "2025-05-09T12:04:48.829Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/ef/c6deb083748be3bcad6f471b6ae983950c161890bf5ae1b2af80cc56c530/trove_classifiers-2025.5.9.12-py3-none-any.whl", hash = "sha256:e381c05537adac78881c8fa345fd0e9970159f4e4a04fcc42cfd3129cca640ce", size = 14119, upload-time = "2025-05-09T12:04:46.38Z" },
 ]
 
 [[package]]
@@ -1909,44 +1564,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
-]
-
-[[package]]
-name = "userpath"
-version = "1.9.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/b7/30753098208505d7ff9be5b3a32112fb8a4cb3ddfccbbb7ba9973f2e29ff/userpath-1.9.2.tar.gz", hash = "sha256:6c52288dab069257cc831846d15d48133522455d4677ee69a9781f11dbefd815", size = 11140, upload-time = "2024-02-29T21:39:08.742Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl", hash = "sha256:2cbf01a23d655a1ff8fc166dfb78da1b641d1ceabf0fe5f970767d380b14e89d", size = 9065, upload-time = "2024-02-29T21:39:07.551Z" },
-]
-
-[[package]]
-name = "uv"
-version = "0.8.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/2c3cb3e992fa1bf9af590bb37983f13e3ae67155820a09a98945664f71f3/uv-0.8.3.tar.gz", hash = "sha256:2ccaae4c749126c99f6404d67a0ae1eae29cbafb05603d09094a775061fdf4e5", size = 3415565, upload-time = "2025-07-24T21:14:34.417Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/ab/7b881bb236b9c5f6d99a98adf0c4d1e7c4f0cf4b49051d6d24eb82f19c10/uv-0.8.3-py3-none-linux_armv6l.whl", hash = "sha256:ae7efe91dcfc24126fa91e0fb69a1daf6c0e494a781ba192bb0cc62d7ab623ee", size = 17912668, upload-time = "2025-07-24T21:13:50.682Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/9b/64d2ed7388ce88971ffb93d45e74465c95bb885bff40c93f5037b7250930/uv-0.8.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:966ec7d7f57521fef0fee685d71e183c9cafb358ddcfe27519dfeaf40550f247", size = 17947557, upload-time = "2025-07-24T21:13:54.59Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/ba/8ceec5d6a1adf6b827db557077d8059e573a84c3708a70433d22a0470fab/uv-0.8.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3f904f574dc2d7aa1d96ddf2483480ecd121dc9d060108cadd8bff100b754b64", size = 16638472, upload-time = "2025-07-24T21:13:57.57Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/76/6d2eb90936603756c4a71f9cf5de8d9214fa4d11dcb5a89117389acecd5e/uv-0.8.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:8b16f1bddfdf8f7470924ab34a7b55e4c372d5340c7c1e47e7fc84a743dc541f", size = 17221472, upload-time = "2025-07-24T21:14:00.158Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/bf/c3e1cc9604b114dfb49a3a40a230b5410fc97776c149ca73bb524990f9ba/uv-0.8.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:526f2c3bd6f311ce31f6f7b6b7d818b191f41e76bed3aaab671b716220c02d8f", size = 17607299, upload-time = "2025-07-24T21:14:02.226Z" },
-    { url = "https://files.pythonhosted.org/packages/53/16/819f876f5ca2f8989c19d9b65b7d794d60e6cca0d13187bbc8c8b5532b52/uv-0.8.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:76de331a07e5ae9b6490e70a9439a072b91b3167a5684510af10c2752c4ece9a", size = 18218124, upload-time = "2025-07-24T21:14:04.809Z" },
-    { url = "https://files.pythonhosted.org/packages/61/a8/1df852a9153fec0c713358a50cfd7a21a4e17b5ed5704a390c0f3da448ab/uv-0.8.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:989898caeb6e972979543b57547d1c28ab8af81ff8fc15921fd354c17d432749", size = 19638846, upload-time = "2025-07-24T21:14:07.074Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/31/adeedaa009d8d919107c52afb58689d5e9db578b07f8dea5e15e4c738d52/uv-0.8.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9ce7981f4fbeecf93dc5cf0a5a7915e84956fd99ad3ac977c048fe0cfdb1a17e", size = 19384261, upload-time = "2025-07-24T21:14:09.425Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/87/b3981f499e2b13c5ef0022fd7809f0fccbecd41282ae4f6a0e3fd5fa1430/uv-0.8.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8486f7576d15cc73509f93f47b3190f44701ea36839906369301b58c8604d5db", size = 18673722, upload-time = "2025-07-24T21:14:11.656Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/62/0d1ba1c666c5492d3716d8d3fba425f65ed2acc6707544c3cbbd381f6cbe/uv-0.8.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1eb7c896fc0d80ed534748aaf46697b6ebc8ce401f1c51666ce0b9923c3db9a", size = 18658829, upload-time = "2025-07-24T21:14:13.798Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/ae/11d09be3c74ca4896d55701ebbca7fe7a32db0502cf9f4c57e20bf77bfc4/uv-0.8.3-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:1121ad1c9389b865d029385031d3fd7d90d343c92a2149a4d4aa20bf469cb27f", size = 17460029, upload-time = "2025-07-24T21:14:15.993Z" },
-    { url = "https://files.pythonhosted.org/packages/22/47/b67296c62381b8369f082a33d9fdcb7c579ad9922bcce7b09cd4af935dfa/uv-0.8.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5313ee776ad65731ffa8ac585246f987d3a2bf72e6153c12add1fff22ad6e500", size = 18398665, upload-time = "2025-07-24T21:14:18.399Z" },
-    { url = "https://files.pythonhosted.org/packages/01/5f/23990de5487085ca86e12f99d0a8f8410419442ffd35c42838675df5549b/uv-0.8.3-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:daa6e0d657a94f20e962d4a03d833ef7af5c8e51b7c8a2d92ba6cf64a4c07ac1", size = 17560408, upload-time = "2025-07-24T21:14:20.609Z" },
-    { url = "https://files.pythonhosted.org/packages/89/42/1a8ce79d2ce7268e52690cd0f1b6c3e6c8d748a68d42de206e37219e9627/uv-0.8.3-py3-none-musllinux_1_1_i686.whl", hash = "sha256:ad13453ab0a1dfa64a221aac8f52199efdcaa52c97134fffd7bcebed794a6f4b", size = 17758504, upload-time = "2025-07-24T21:14:23.086Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/39/ae94e06ac00cb5002e636af0e48c5180fab5b50a463dc96386875ea511ea/uv-0.8.3-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:5843cc43bafad05cc710d8e31bd347ee37202462a63d32c30746e9df48cfbda2", size = 18741736, upload-time = "2025-07-24T21:14:25.329Z" },
-    { url = "https://files.pythonhosted.org/packages/18/e0/a2fe9cc5f7b8815cbf97cb1bf64abb71fcb65f25ca7a5a8cdd4c2e23af97/uv-0.8.3-py3-none-win32.whl", hash = "sha256:17bcdb0615e37cc5f985f7d7546f755ac6343c1dc8bbe876c892437f14f8f904", size = 17723422, upload-time = "2025-07-24T21:14:28.02Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/c3/da508ec0f6883f1c269a0a477bb6447c81d5383fe3ad5d5ea3d45469fd30/uv-0.8.3-py3-none-win_amd64.whl", hash = "sha256:2e311c029bff2ca07c6ddf877ccc5935cabb78e09b94b53a849542665b6a6fa1", size = 19531666, upload-time = "2025-07-24T21:14:30.192Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/8d/c0354e416697b4baa7ceaad0e423639b6683d1f8299355e390a64809f7bf/uv-0.8.3-py3-none-win_arm64.whl", hash = "sha256:391c97577048a40fd8c85b370055df6420f26e81df7fa906f0e0ce1aa2af3527", size = 18161557, upload-time = "2025-07-24T21:14:32.482Z" },
 ]
 
 [[package]]
@@ -2176,88 +1793,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/24/fd/725b8e73ac2a50e78a4534ac43c6addf5c1c2d65380dd48a9169cc6739a9/yarl-1.20.1-cp313-cp313t-win32.whl", hash = "sha256:b121ff6a7cbd4abc28985b6028235491941b9fe8fe226e6fdc539c977ea1739d", size = 86591, upload-time = "2025-06-10T00:45:25.793Z" },
     { url = "https://files.pythonhosted.org/packages/94/c3/b2e9f38bc3e11191981d57ea08cab2166e74ea770024a646617c9cddd9f6/yarl-1.20.1-cp313-cp313t-win_amd64.whl", hash = "sha256:541d050a355bbbc27e55d906bc91cb6fe42f96c01413dd0f4ed5a5240513874f", size = 93003, upload-time = "2025-06-10T00:45:27.752Z" },
     { url = "https://files.pythonhosted.org/packages/b4/2d/2345fce04cfd4bee161bf1e7d9cdc702e3e16109021035dbb24db654a622/yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77", size = 46542, upload-time = "2025-06-10T00:46:07.521Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
-]
-
-[[package]]
-name = "zstandard"
-version = "0.23.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation == 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/f6/2ac0287b442160a89d726b17a9184a4c615bb5237db763791a7fd16d9df1/zstandard-0.23.0.tar.gz", hash = "sha256:b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09", size = 681701, upload-time = "2024-07-15T00:18:06.141Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/55/bd0487e86679db1823fc9ee0d8c9c78ae2413d34c0b461193b5f4c31d22f/zstandard-0.23.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bf0a05b6059c0528477fba9054d09179beb63744355cab9f38059548fedd46a9", size = 788701, upload-time = "2024-07-15T00:13:27.351Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/8a/ccb516b684f3ad987dfee27570d635822e3038645b1a950c5e8022df1145/zstandard-0.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc9ca1c9718cb3b06634c7c8dec57d24e9438b2aa9a0f02b8bb36bf478538880", size = 633678, upload-time = "2024-07-15T00:13:30.24Z" },
-    { url = "https://files.pythonhosted.org/packages/12/89/75e633d0611c028e0d9af6df199423bf43f54bea5007e6718ab7132e234c/zstandard-0.23.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77da4c6bfa20dd5ea25cbf12c76f181a8e8cd7ea231c673828d0386b1740b8dc", size = 4941098, upload-time = "2024-07-15T00:13:32.526Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/7a/bd7f6a21802de358b63f1ee636ab823711c25ce043a3e9f043b4fcb5ba32/zstandard-0.23.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2170c7e0367dde86a2647ed5b6f57394ea7f53545746104c6b09fc1f4223573", size = 5308798, upload-time = "2024-07-15T00:13:34.925Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3b/775f851a4a65013e88ca559c8ae42ac1352db6fcd96b028d0df4d7d1d7b4/zstandard-0.23.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c16842b846a8d2a145223f520b7e18b57c8f476924bda92aeee3a88d11cfc391", size = 5341840, upload-time = "2024-07-15T00:13:37.376Z" },
-    { url = "https://files.pythonhosted.org/packages/09/4f/0cc49570141dd72d4d95dd6fcf09328d1b702c47a6ec12fbed3b8aed18a5/zstandard-0.23.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:157e89ceb4054029a289fb504c98c6a9fe8010f1680de0201b3eb5dc20aa6d9e", size = 5440337, upload-time = "2024-07-15T00:13:39.772Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/7c/aaa7cd27148bae2dc095191529c0570d16058c54c4597a7d118de4b21676/zstandard-0.23.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:203d236f4c94cd8379d1ea61db2fce20730b4c38d7f1c34506a31b34edc87bdd", size = 4861182, upload-time = "2024-07-15T00:13:42.495Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/eb/4b58b5c071d177f7dc027129d20bd2a44161faca6592a67f8fcb0b88b3ae/zstandard-0.23.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:dc5d1a49d3f8262be192589a4b72f0d03b72dcf46c51ad5852a4fdc67be7b9e4", size = 4932936, upload-time = "2024-07-15T00:13:44.234Z" },
-    { url = "https://files.pythonhosted.org/packages/44/f9/21a5fb9bb7c9a274b05ad700a82ad22ce82f7ef0f485980a1e98ed6e8c5f/zstandard-0.23.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:752bf8a74412b9892f4e5b58f2f890a039f57037f52c89a740757ebd807f33ea", size = 5464705, upload-time = "2024-07-15T00:13:46.822Z" },
-    { url = "https://files.pythonhosted.org/packages/49/74/b7b3e61db3f88632776b78b1db597af3f44c91ce17d533e14a25ce6a2816/zstandard-0.23.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:80080816b4f52a9d886e67f1f96912891074903238fe54f2de8b786f86baded2", size = 4857882, upload-time = "2024-07-15T00:13:49.297Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/7f/d8eb1cb123d8e4c541d4465167080bec88481ab54cd0b31eb4013ba04b95/zstandard-0.23.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84433dddea68571a6d6bd4fbf8ff398236031149116a7fff6f777ff95cad3df9", size = 4697672, upload-time = "2024-07-15T00:13:51.447Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/05/f7dccdf3d121309b60342da454d3e706453a31073e2c4dac8e1581861e44/zstandard-0.23.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ab19a2d91963ed9e42b4e8d77cd847ae8381576585bad79dbd0a8837a9f6620a", size = 5206043, upload-time = "2024-07-15T00:13:53.587Z" },
-    { url = "https://files.pythonhosted.org/packages/86/9d/3677a02e172dccd8dd3a941307621c0cbd7691d77cb435ac3c75ab6a3105/zstandard-0.23.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:59556bf80a7094d0cfb9f5e50bb2db27fefb75d5138bb16fb052b61b0e0eeeb0", size = 5667390, upload-time = "2024-07-15T00:13:56.137Z" },
-    { url = "https://files.pythonhosted.org/packages/41/7e/0012a02458e74a7ba122cd9cafe491facc602c9a17f590367da369929498/zstandard-0.23.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:27d3ef2252d2e62476389ca8f9b0cf2bbafb082a3b6bfe9d90cbcbb5529ecf7c", size = 5198901, upload-time = "2024-07-15T00:13:58.584Z" },
-    { url = "https://files.pythonhosted.org/packages/65/3a/8f715b97bd7bcfc7342d8adcd99a026cb2fb550e44866a3b6c348e1b0f02/zstandard-0.23.0-cp310-cp310-win32.whl", hash = "sha256:5d41d5e025f1e0bccae4928981e71b2334c60f580bdc8345f824e7c0a4c2a813", size = 430596, upload-time = "2024-07-15T00:14:00.693Z" },
-    { url = "https://files.pythonhosted.org/packages/19/b7/b2b9eca5e5a01111e4fe8a8ffb56bdcdf56b12448a24effe6cfe4a252034/zstandard-0.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:519fbf169dfac1222a76ba8861ef4ac7f0530c35dd79ba5727014613f91613d4", size = 495498, upload-time = "2024-07-15T00:14:02.741Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/40/f67e7d2c25a0e2dc1744dd781110b0b60306657f8696cafb7ad7579469bd/zstandard-0.23.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:34895a41273ad33347b2fc70e1bff4240556de3c46c6ea430a7ed91f9042aa4e", size = 788699, upload-time = "2024-07-15T00:14:04.909Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/46/66d5b55f4d737dd6ab75851b224abf0afe5774976fe511a54d2eb9063a41/zstandard-0.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:77ea385f7dd5b5676d7fd943292ffa18fbf5c72ba98f7d09fc1fb9e819b34c23", size = 633681, upload-time = "2024-07-15T00:14:13.99Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/677e65c095d8e12b66b8f862b069bcf1f1d781b9c9c6f12eb55000d57583/zstandard-0.23.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:983b6efd649723474f29ed42e1467f90a35a74793437d0bc64a5bf482bedfa0a", size = 4944328, upload-time = "2024-07-15T00:14:16.588Z" },
-    { url = "https://files.pythonhosted.org/packages/59/cc/e76acb4c42afa05a9d20827116d1f9287e9c32b7ad58cc3af0721ce2b481/zstandard-0.23.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80a539906390591dd39ebb8d773771dc4db82ace6372c4d41e2d293f8e32b8db", size = 5311955, upload-time = "2024-07-15T00:14:19.389Z" },
-    { url = "https://files.pythonhosted.org/packages/78/e4/644b8075f18fc7f632130c32e8f36f6dc1b93065bf2dd87f03223b187f26/zstandard-0.23.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:445e4cb5048b04e90ce96a79b4b63140e3f4ab5f662321975679b5f6360b90e2", size = 5344944, upload-time = "2024-07-15T00:14:22.173Z" },
-    { url = "https://files.pythonhosted.org/packages/76/3f/dbafccf19cfeca25bbabf6f2dd81796b7218f768ec400f043edc767015a6/zstandard-0.23.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd30d9c67d13d891f2360b2a120186729c111238ac63b43dbd37a5a40670b8ca", size = 5442927, upload-time = "2024-07-15T00:14:24.825Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/c3/d24a01a19b6733b9f218e94d1a87c477d523237e07f94899e1c10f6fd06c/zstandard-0.23.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d20fd853fbb5807c8e84c136c278827b6167ded66c72ec6f9a14b863d809211c", size = 4864910, upload-time = "2024-07-15T00:14:26.982Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/a9/cf8f78ead4597264f7618d0875be01f9bc23c9d1d11afb6d225b867cb423/zstandard-0.23.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ed1708dbf4d2e3a1c5c69110ba2b4eb6678262028afd6c6fbcc5a8dac9cda68e", size = 4935544, upload-time = "2024-07-15T00:14:29.582Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/96/8af1e3731b67965fb995a940c04a2c20997a7b3b14826b9d1301cf160879/zstandard-0.23.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:be9b5b8659dff1f913039c2feee1aca499cfbc19e98fa12bc85e037c17ec6ca5", size = 5467094, upload-time = "2024-07-15T00:14:40.126Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/57/43ea9df642c636cb79f88a13ab07d92d88d3bfe3e550b55a25a07a26d878/zstandard-0.23.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:65308f4b4890aa12d9b6ad9f2844b7ee42c7f7a4fd3390425b242ffc57498f48", size = 4860440, upload-time = "2024-07-15T00:14:42.786Z" },
-    { url = "https://files.pythonhosted.org/packages/46/37/edb78f33c7f44f806525f27baa300341918fd4c4af9472fbc2c3094be2e8/zstandard-0.23.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:98da17ce9cbf3bfe4617e836d561e433f871129e3a7ac16d6ef4c680f13a839c", size = 4700091, upload-time = "2024-07-15T00:14:45.184Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/f1/454ac3962671a754f3cb49242472df5c2cced4eb959ae203a377b45b1a3c/zstandard-0.23.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:8ed7d27cb56b3e058d3cf684d7200703bcae623e1dcc06ed1e18ecda39fee003", size = 5208682, upload-time = "2024-07-15T00:14:47.407Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b2/1734b0fff1634390b1b887202d557d2dd542de84a4c155c258cf75da4773/zstandard-0.23.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:b69bb4f51daf461b15e7b3db033160937d3ff88303a7bc808c67bbc1eaf98c78", size = 5669707, upload-time = "2024-07-15T00:15:03.529Z" },
-    { url = "https://files.pythonhosted.org/packages/52/5a/87d6971f0997c4b9b09c495bf92189fb63de86a83cadc4977dc19735f652/zstandard-0.23.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:034b88913ecc1b097f528e42b539453fa82c3557e414b3de9d5632c80439a473", size = 5201792, upload-time = "2024-07-15T00:15:28.372Z" },
-    { url = "https://files.pythonhosted.org/packages/79/02/6f6a42cc84459d399bd1a4e1adfc78d4dfe45e56d05b072008d10040e13b/zstandard-0.23.0-cp311-cp311-win32.whl", hash = "sha256:f2d4380bf5f62daabd7b751ea2339c1a21d1c9463f1feb7fc2bdcea2c29c3160", size = 430586, upload-time = "2024-07-15T00:15:32.26Z" },
-    { url = "https://files.pythonhosted.org/packages/be/a2/4272175d47c623ff78196f3c10e9dc7045c1b9caf3735bf041e65271eca4/zstandard-0.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:62136da96a973bd2557f06ddd4e8e807f9e13cbb0bfb9cc06cfe6d98ea90dfe0", size = 495420, upload-time = "2024-07-15T00:15:34.004Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/83/f23338c963bd9de687d47bf32efe9fd30164e722ba27fb59df33e6b1719b/zstandard-0.23.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b4567955a6bc1b20e9c31612e615af6b53733491aeaa19a6b3b37f3b65477094", size = 788713, upload-time = "2024-07-15T00:15:35.815Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/b3/1a028f6750fd9227ee0b937a278a434ab7f7fdc3066c3173f64366fe2466/zstandard-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e172f57cd78c20f13a3415cc8dfe24bf388614324d25539146594c16d78fcc8", size = 633459, upload-time = "2024-07-15T00:15:37.995Z" },
-    { url = "https://files.pythonhosted.org/packages/26/af/36d89aae0c1f95a0a98e50711bc5d92c144939efc1f81a2fcd3e78d7f4c1/zstandard-0.23.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0e166f698c5a3e914947388c162be2583e0c638a4703fc6a543e23a88dea3c1", size = 4945707, upload-time = "2024-07-15T00:15:39.872Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/2e/2051f5c772f4dfc0aae3741d5fc72c3dcfe3aaeb461cc231668a4db1ce14/zstandard-0.23.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12a289832e520c6bd4dcaad68e944b86da3bad0d339ef7989fb7e88f92e96072", size = 5306545, upload-time = "2024-07-15T00:15:41.75Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/9e/a11c97b087f89cab030fa71206963090d2fecd8eb83e67bb8f3ffb84c024/zstandard-0.23.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d50d31bfedd53a928fed6707b15a8dbeef011bb6366297cc435accc888b27c20", size = 5337533, upload-time = "2024-07-15T00:15:44.114Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/79/edeb217c57fe1bf16d890aa91a1c2c96b28c07b46afed54a5dcf310c3f6f/zstandard-0.23.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72c68dda124a1a138340fb62fa21b9bf4848437d9ca60bd35db36f2d3345f373", size = 5436510, upload-time = "2024-07-15T00:15:46.509Z" },
-    { url = "https://files.pythonhosted.org/packages/81/4f/c21383d97cb7a422ddf1ae824b53ce4b51063d0eeb2afa757eb40804a8ef/zstandard-0.23.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53dd9d5e3d29f95acd5de6802e909ada8d8d8cfa37a3ac64836f3bc4bc5512db", size = 4859973, upload-time = "2024-07-15T00:15:49.939Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/15/08d22e87753304405ccac8be2493a495f529edd81d39a0870621462276ef/zstandard-0.23.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:6a41c120c3dbc0d81a8e8adc73312d668cd34acd7725f036992b1b72d22c1772", size = 4936968, upload-time = "2024-07-15T00:15:52.025Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/fa/f3670a597949fe7dcf38119a39f7da49a8a84a6f0b1a2e46b2f71a0ab83f/zstandard-0.23.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:40b33d93c6eddf02d2c19f5773196068d875c41ca25730e8288e9b672897c105", size = 5467179, upload-time = "2024-07-15T00:15:54.971Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/a9/dad2ab22020211e380adc477a1dbf9f109b1f8d94c614944843e20dc2a99/zstandard-0.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9206649ec587e6b02bd124fb7799b86cddec350f6f6c14bc82a2b70183e708ba", size = 4848577, upload-time = "2024-07-15T00:15:57.634Z" },
-    { url = "https://files.pythonhosted.org/packages/08/03/dd28b4484b0770f1e23478413e01bee476ae8227bbc81561f9c329e12564/zstandard-0.23.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:76e79bc28a65f467e0409098fa2c4376931fd3207fbeb6b956c7c476d53746dd", size = 4693899, upload-time = "2024-07-15T00:16:00.811Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/64/3da7497eb635d025841e958bcd66a86117ae320c3b14b0ae86e9e8627518/zstandard-0.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:66b689c107857eceabf2cf3d3fc699c3c0fe8ccd18df2219d978c0283e4c508a", size = 5199964, upload-time = "2024-07-15T00:16:03.669Z" },
-    { url = "https://files.pythonhosted.org/packages/43/a4/d82decbab158a0e8a6ebb7fc98bc4d903266bce85b6e9aaedea1d288338c/zstandard-0.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:9c236e635582742fee16603042553d276cca506e824fa2e6489db04039521e90", size = 5655398, upload-time = "2024-07-15T00:16:06.694Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/61/ac78a1263bc83a5cf29e7458b77a568eda5a8f81980691bbc6eb6a0d45cc/zstandard-0.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a8fffdbd9d1408006baaf02f1068d7dd1f016c6bcb7538682622c556e7b68e35", size = 5191313, upload-time = "2024-07-15T00:16:09.758Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/54/967c478314e16af5baf849b6ee9d6ea724ae5b100eb506011f045d3d4e16/zstandard-0.23.0-cp312-cp312-win32.whl", hash = "sha256:dc1d33abb8a0d754ea4763bad944fd965d3d95b5baef6b121c0c9013eaf1907d", size = 430877, upload-time = "2024-07-15T00:16:11.758Z" },
-    { url = "https://files.pythonhosted.org/packages/75/37/872d74bd7739639c4553bf94c84af7d54d8211b626b352bc57f0fd8d1e3f/zstandard-0.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:64585e1dba664dc67c7cdabd56c1e5685233fbb1fc1966cfba2a340ec0dfff7b", size = 495595, upload-time = "2024-07-15T00:16:13.731Z" },
-    { url = "https://files.pythonhosted.org/packages/80/f1/8386f3f7c10261fe85fbc2c012fdb3d4db793b921c9abcc995d8da1b7a80/zstandard-0.23.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:576856e8594e6649aee06ddbfc738fec6a834f7c85bf7cadd1c53d4a58186ef9", size = 788975, upload-time = "2024-07-15T00:16:16.005Z" },
-    { url = "https://files.pythonhosted.org/packages/16/e8/cbf01077550b3e5dc86089035ff8f6fbbb312bc0983757c2d1117ebba242/zstandard-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:38302b78a850ff82656beaddeb0bb989a0322a8bbb1bf1ab10c17506681d772a", size = 633448, upload-time = "2024-07-15T00:16:17.897Z" },
-    { url = "https://files.pythonhosted.org/packages/06/27/4a1b4c267c29a464a161aeb2589aff212b4db653a1d96bffe3598f3f0d22/zstandard-0.23.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2240ddc86b74966c34554c49d00eaafa8200a18d3a5b6ffbf7da63b11d74ee2", size = 4945269, upload-time = "2024-07-15T00:16:20.136Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/64/d99261cc57afd9ae65b707e38045ed8269fbdae73544fd2e4a4d50d0ed83/zstandard-0.23.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2ef230a8fd217a2015bc91b74f6b3b7d6522ba48be29ad4ea0ca3a3775bf7dd5", size = 5306228, upload-time = "2024-07-15T00:16:23.398Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/cf/27b74c6f22541f0263016a0fd6369b1b7818941de639215c84e4e94b2a1c/zstandard-0.23.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:774d45b1fac1461f48698a9d4b5fa19a69d47ece02fa469825b442263f04021f", size = 5336891, upload-time = "2024-07-15T00:16:26.391Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/18/89ac62eac46b69948bf35fcd90d37103f38722968e2981f752d69081ec4d/zstandard-0.23.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f77fa49079891a4aab203d0b1744acc85577ed16d767b52fc089d83faf8d8ed", size = 5436310, upload-time = "2024-07-15T00:16:29.018Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/a8/5ca5328ee568a873f5118d5b5f70d1f36c6387716efe2e369010289a5738/zstandard-0.23.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ac184f87ff521f4840e6ea0b10c0ec90c6b1dcd0bad2f1e4a9a1b4fa177982ea", size = 4859912, upload-time = "2024-07-15T00:16:31.871Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/ca/3781059c95fd0868658b1cf0440edd832b942f84ae60685d0cfdb808bca1/zstandard-0.23.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c363b53e257246a954ebc7c488304b5592b9c53fbe74d03bc1c64dda153fb847", size = 4936946, upload-time = "2024-07-15T00:16:34.593Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/11/41a58986f809532742c2b832c53b74ba0e0a5dae7e8ab4642bf5876f35de/zstandard-0.23.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e7792606d606c8df5277c32ccb58f29b9b8603bf83b48639b7aedf6df4fe8171", size = 5466994, upload-time = "2024-07-15T00:16:36.887Z" },
-    { url = "https://files.pythonhosted.org/packages/83/e3/97d84fe95edd38d7053af05159465d298c8b20cebe9ccb3d26783faa9094/zstandard-0.23.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a0817825b900fcd43ac5d05b8b3079937073d2b1ff9cf89427590718b70dd840", size = 4848681, upload-time = "2024-07-15T00:16:39.709Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/99/cb1e63e931de15c88af26085e3f2d9af9ce53ccafac73b6e48418fd5a6e6/zstandard-0.23.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9da6bc32faac9a293ddfdcb9108d4b20416219461e4ec64dfea8383cac186690", size = 4694239, upload-time = "2024-07-15T00:16:41.83Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/50/b1e703016eebbc6501fc92f34db7b1c68e54e567ef39e6e59cf5fb6f2ec0/zstandard-0.23.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fd7699e8fd9969f455ef2926221e0233f81a2542921471382e77a9e2f2b57f4b", size = 5200149, upload-time = "2024-07-15T00:16:44.287Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e0/932388630aaba70197c78bdb10cce2c91fae01a7e553b76ce85471aec690/zstandard-0.23.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d477ed829077cd945b01fc3115edd132c47e6540ddcd96ca169facff28173057", size = 5655392, upload-time = "2024-07-15T00:16:46.423Z" },
-    { url = "https://files.pythonhosted.org/packages/02/90/2633473864f67a15526324b007a9f96c96f56d5f32ef2a56cc12f9548723/zstandard-0.23.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa6ce8b52c5987b3e34d5674b0ab529a4602b632ebab0a93b07bfb4dfc8f8a33", size = 5191299, upload-time = "2024-07-15T00:16:49.053Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4c/315ca5c32da7e2dc3455f3b2caee5c8c2246074a61aac6ec3378a97b7136/zstandard-0.23.0-cp313-cp313-win32.whl", hash = "sha256:a9b07268d0c3ca5c170a385a0ab9fb7fdd9f5fd866be004c4ea39e44edce47dd", size = 430862, upload-time = "2024-07-15T00:16:51.003Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/bf/c6aaba098e2d04781e8f4f7c0ba3c7aa73d00e4c436bcc0cf059a66691d1/zstandard-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:f3513916e8c645d0610815c257cbfd3242adfd5c4cfa78be514e5a3ebb42a41b", size = 495578, upload-time = "2024-07-15T00:16:53.135Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "cloud-autopkg-runner"
-version = "0.16.1"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
This update adds a class called `GitClient`. The class wraps many common `git` commands with the hope that developers will not need to write their own middleware to interact with git repositories.