### PR TITLE
Expand tilde paths, handle missing etag or last modified attributes

### DIFF
--- a/src/cloud_autopkg_runner/file_utils.py
+++ b/src/cloud_autopkg_runner/file_utils.py
@@ -120,7 +120,7 @@ async def create_placeholder_files(recipe_list: Iterable[str]) -> None:
                 )
                 continue
 
-            file_path = Path(the_cache.get("file_path", ""))
+            file_path = Path(the_cache.get("file_path", "")).expanduser()
             if file_path.exists():
                 logger.info("Skipping file creation: %s already exists.", file_path)
                 continue

--- a/src/cloud_autopkg_runner/file_utils.py
+++ b/src/cloud_autopkg_runner/file_utils.py
@@ -136,7 +136,7 @@ async def create_placeholder_files(recipe_list: Iterable[str]) -> None:
     logger.debug("Placeholder files created.")
 
 
-async def get_file_metadata(file_path: Path, attr: str) -> str:
+async def get_file_metadata(file_path: Path, attr: str) -> str | None:
     """Get extended file metadata.
 
     Args:
@@ -144,16 +144,23 @@ async def get_file_metadata(file_path: Path, attr: str) -> str:
         attr: the attribute of the extended metadata.
 
     Returns:
-        The decoded string representation of the extended attribute metadata.
+        The decoded string representation of the extended attribute metadata,
+        or None if the attribute doesn't exist.
     """
-    return await asyncio.to_thread(
-        lambda: cast(
-            "bytes",
-            xattr.getxattr(  # pyright: ignore[reportUnknownMemberType]
-                file_path, attr
-            ),
-        ).decode()
-    )
+    try:
+        return await asyncio.to_thread(
+            lambda: cast(
+                "bytes",
+                xattr.getxattr(  # pyright: ignore[reportUnknownMemberType]
+                    file_path, attr
+                ),
+            ).decode()
+        )
+    except OSError as e:
+        # Errno 93 means the attribute doesn't exist
+        if e.errno == 93:
+            return None
+        raise
 
 
 async def get_file_size(file_path: Path) -> int:

--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -498,7 +498,7 @@ class Recipe:
             file size (`int` or `None`), last modified date (`str` or `None`),
             and the original file path (`str`) of the downloaded item.
         """
-        downloaded_item_path: Path = Path(downloaded_item)
+        downloaded_item_path: Path = Path(downloaded_item).expanduser()
 
         etag_task = file_utils.get_file_metadata(
             downloaded_item_path, "com.github.autopkg.etag"

--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -514,9 +514,9 @@ class Recipe:
         )
 
         return {
-            "etag": etag,
+            "etag": etag or "",
             "file_size": file_size,
-            "last_modified": last_modified,
+            "last_modified": last_modified or "",
             "file_path": downloaded_item,
         }
 


### PR DESCRIPTION
This PR allows expansion of tilde paths (`~/Library/...`) in AutoPkg recipe outputs that otherwise caused cloud-autopkg-runner to crash when attempting to access file metadata.

It also gracefully handles missing etag or last modified metadata.