### PR TITLE
Cache download metadata only after a successful run

### DIFF
--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -578,9 +578,9 @@ class Recipe:
 
         This asynchronous method orchestrates the execution of an AutoPkg recipe.
         It first performs a "check phase" to determine if there are any updates
-        available. If updates lead to downloaded items, it then extracts metadata from
-        these downloaded files, saves this metadata to the configured cache using the
-        `metadata_cache` plugin, and finally performs a full run of the recipe. If no
+        available. If updates lead to downloaded items, it then performs a full run of
+        the recipe. If that full run succeeds, metadata is extracted from the downloaded
+        files and saved to the configured cache using the `metadata_cache` plugin. If no
         new downloads are detected during the check phase, the full run is skipped, and
         the report from the check phase is returned.
 
@@ -591,17 +591,28 @@ class Recipe:
         # First, run the check phase to see if there are any updates
         output: ConsolidatedReport = await self.run_check_phase()
 
-        # If the check phase indicates new downloads or built packages, process metadata
-        # and run the full recipe
+        # If the check phase indicates new downloads or built packages, run the full
+        # recipe, then cache the download metadata only if that run succeeded
         if output["downloaded_items"] or output["pkg_built_items"]:
             self._logger.info(
                 "New downloads detected for %s. Running full recipe.", self.name
             )
-            metadata: RecipeCache = await self._get_metadata(output["downloaded_items"])
-            metadata_cache_manager = metadata_cache.get_cache_plugin()
-            await metadata_cache_manager.set_item(self.name, metadata)
+            report: ConsolidatedReport = await self.run_full()
 
-            return await self.run_full()
+            if report["failed_items"]:
+                self._logger.warning(
+                    "%s failed, so its download metadata was not cached. "
+                    "The next run will retry the download.",
+                    self.name,
+                )
+            else:
+                metadata: RecipeCache = await self._get_metadata(
+                    output["downloaded_items"]
+                )
+                metadata_cache_manager = metadata_cache.get_cache_plugin()
+                await metadata_cache_manager.set_item(self.name, metadata)
+
+            return report
 
         self._logger.info(
             "No new downloads for %s. Skipping full recipe run.", self.name

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -12,6 +12,7 @@ from cloud_autopkg_runner.exceptions import (
     RecipeInputError,
 )
 from cloud_autopkg_runner.recipe import RecipeContents, RecipeFormat
+from cloud_autopkg_runner.recipe_report import ConsolidatedReport
 
 
 def create_test_file(path: Path, content: str) -> None:
@@ -534,3 +535,99 @@ async def test_get_metadata_for_item_last_modified_error() -> None:
         mock_get_file_metadata.assert_any_call(
             test_file_path, "com.github.autopkg.last-modified"
         )
+
+
+def _run_test_recipe(tmp_path: Path, mock_autopkg_prefs: MagicMock) -> Recipe:
+    """Creates a minimal Recipe for exercising `run`.
+
+    Returns:
+        Recipe: A Recipe object backed by a throwaway YAML file.
+    """
+    recipe_file = tmp_path / "Test.recipe.yaml"
+    create_test_file(
+        recipe_file,
+        """
+    Description: Test
+    Identifier: com.example.test
+    Input:
+        NAME: TestRecipe
+    Process: []
+    """,
+    )
+    return Recipe(recipe_file, tmp_path, mock_autopkg_prefs)
+
+
+def _consolidated_report(*, failed: bool) -> ConsolidatedReport:
+    """Builds a report with one downloaded item and optionally one failure.
+
+    Returns:
+        ConsolidatedReport: A report suitable for stubbing out a recipe run.
+    """
+    return ConsolidatedReport(
+        failed_items=[{"recipe": "Test.recipe.yaml", "message": "boom"}]
+        if failed
+        else [],
+        downloaded_items=[{"download_path": "/tmp/Test.dmg"}],
+        pkg_built_items=[],
+        munki_imported_items=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_caches_metadata_after_successful_full_run(
+    tmp_path: Path, mock_autopkg_prefs: MagicMock
+) -> None:
+    """Metadata is cached once the full run reports no failures."""
+    mock_cache = AsyncMock()
+
+    with (
+        patch("cloud_autopkg_runner.recipe.Settings"),
+        patch(
+            "cloud_autopkg_runner.recipe.metadata_cache.get_cache_plugin",
+            return_value=mock_cache,
+        ),
+    ):
+        recipe = _run_test_recipe(tmp_path, mock_autopkg_prefs)
+        recipe.run_check_phase = AsyncMock(  # type: ignore[method-assign]
+            return_value=_consolidated_report(failed=False)
+        )
+        recipe.run_full = AsyncMock(  # type: ignore[method-assign]
+            return_value=_consolidated_report(failed=False)
+        )
+        recipe._get_metadata = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        report = await recipe.run()
+
+        recipe.run_full.assert_awaited_once()
+        mock_cache.set_item.assert_awaited_once()
+        assert report["failed_items"] == []
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_cache_metadata_after_failed_full_run(
+    tmp_path: Path, mock_autopkg_prefs: MagicMock
+) -> None:
+    """A failed full run leaves the cache alone so the next run retries."""
+    mock_cache = AsyncMock()
+
+    with (
+        patch("cloud_autopkg_runner.recipe.Settings"),
+        patch(
+            "cloud_autopkg_runner.recipe.metadata_cache.get_cache_plugin",
+            return_value=mock_cache,
+        ),
+    ):
+        recipe = _run_test_recipe(tmp_path, mock_autopkg_prefs)
+        recipe.run_check_phase = AsyncMock(  # type: ignore[method-assign]
+            return_value=_consolidated_report(failed=False)
+        )
+        recipe.run_full = AsyncMock(  # type: ignore[method-assign]
+            return_value=_consolidated_report(failed=True)
+        )
+        recipe._get_metadata = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        report = await recipe.run()
+
+        recipe.run_full.assert_awaited_once()
+        mock_cache.set_item.assert_not_awaited()
+        assert report["failed_items"]


### PR DESCRIPTION
`Recipe.run()` saves a recipe's download metadata to the cache before the full run, and doesn't roll it back if that run fails. A failed download therefore still records its new ETag, so the next check phase reports no new downloads and skips the recipe. Nothing ever invalidates the entry, so that recipe stops importing indefinitely.

A Tableau Desktop recipe of ours got there last night. The check phase read the vendor's ETag fine, the cache entry was written, and then the download itself was refused:

```
01:58:48 INFO    TableauDesktop_arm64  New downloads detected for TableauDesktop_arm64.munki.recipe.yaml. Running full recipe.
01:58:48 DEBUG   TableauDesktop_arm64  Setting recipe TableauDesktop_arm64.munki.recipe.yaml to {'timestamp': ..., 'etag': '"e6b677d4145dda56150514785c3e1933:1784563809.759217"', ...} in the metadata cache.
01:58:57 DEBUG   TableauDesktop_arm64  Command output:
Error in local.munki.TableauDesktop_arm64: Processor: URLDownloader: Error: curl: (56) The requested URL returned error: 403
```

The 403 was transient and the next run downloaded the file without complaint. The cached ETag would not have been transient. We got away with it only because our cache file path happened to be unwritable, so nothing persisted.

This moves `set_item` to after `run_full()` and caches only when the report has no failed items, with a warning line when it doesn't. Tests cover both branches.

Thanks for considering!
