### PR TITLE
Improve test isolation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,11 +51,13 @@ def _reset_singletons() -> None:
 def reset_singletons() -> Generator[None, None, None]:
     """Fixture to reset the singleton instances around each test.
 
+    Applies to the unit and integration suites alike.
+
     Settings, PluginManager, and every cache backend cache their first
     instance for the lifetime of the process. Each cache backend also latches
-    onto the cache file it was constructed with, so without this the first
-    test to touch the cache pins that file and its contents for every test
-    that follows.
+    onto the container and cache file it was constructed with, along with the
+    data it has already loaded, so without this the first test to touch the
+    cache pins all of that for every test that follows.
 
     Resetting before as well as after keeps a test from inheriting state built
     during collection or left behind by a test that errored.

--- a/tests/integration/test_azure.py
+++ b/tests/integration/test_azure.py
@@ -34,7 +34,11 @@ def generate_unique_name(prefix: str) -> str:
 
 @pytest.fixture
 def settings() -> Settings:
-    """Setup the Settings class."""
+    """Setup the Settings class.
+
+    Returns:
+        Settings: Settings pointing at a container unique to this test.
+    """
     settings = Settings()
     settings.cache_plugin = "azure"
     settings.cloud_container_name = generate_unique_name("cloud-autopkg-test-azure")
@@ -43,9 +47,7 @@ def settings() -> Settings:
         "AZURE_ACCOUNT_URL", "https://127.0.0.1:10000/devstoreaccount1"
     )
 
-    yield settings
-
-    Settings._instance = None
+    return settings
 
 
 @pytest.fixture

--- a/tests/integration/test_gcs.py
+++ b/tests/integration/test_gcs.py
@@ -29,15 +29,17 @@ def generate_unique_name(prefix: str) -> str:
 
 @pytest.fixture
 def settings() -> Settings:
-    """Setup the Settings class."""
+    """Setup the Settings class.
+
+    Returns:
+        Settings: Settings pointing at a bucket unique to this test.
+    """
     settings = Settings()
     settings.cache_plugin = "gcs"
     settings.cloud_container_name = generate_unique_name("cloud-autopkg-test-gcs")
     settings.cache_file = "metadata_cache.json"
 
-    yield settings
-
-    Settings._instance = None
+    return settings
 
 
 @pytest.fixture

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -31,15 +31,17 @@ def generate_unique_name(prefix: str) -> str:
 
 @pytest.fixture
 def settings() -> Settings:
-    """Setup the Settings class."""
+    """Setup the Settings class.
+
+    Returns:
+        Settings: Settings pointing at a bucket unique to this test.
+    """
     settings = Settings()
     settings.cache_plugin = "s3"
     settings.cloud_container_name = generate_unique_name("cloud-autopkg-test-s3")
     settings.cache_file = "metadata_cache.json"
 
-    yield settings
-
-    Settings._instance = None
+    return settings
 
 
 @pytest.fixture

--- a/tests/unit/cache/test_azure_blob_cache.py
+++ b/tests/unit/cache/test_azure_blob_cache.py
@@ -16,20 +16,16 @@ if TYPE_CHECKING:
 @pytest_asyncio.fixture
 async def azure_cache() -> Generator[AsyncAzureBlobCache, Any, None]:
     """Fixture to create an AsyncS3Cache instance with mocks."""
-    with (
-        patch.object(Settings, "_instance", None),
-        patch.object(AsyncAzureBlobCache, "_instance", None),
-    ):
-        settings = Settings()
-        settings.azure_account_url = "https://testaccount.blob.core.windows.net"
-        settings.cloud_container_name = "test-container"
-        settings.cache_file = "metadata_cache.json"
+    settings = Settings()
+    settings.azure_account_url = "https://testaccount.blob.core.windows.net"
+    settings.cloud_container_name = "test-container"
+    settings.cache_file = "metadata_cache.json"
 
-        cache = AsyncAzureBlobCache()
-        cache._client = AsyncMock(spec=BlobClient)
+    cache = AsyncAzureBlobCache()
+    cache._client = AsyncMock(spec=BlobClient)
 
-        yield cache
-        await cache.close()
+    yield cache
+    await cache.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cache/test_gcs_cache.py
+++ b/tests/unit/cache/test_gcs_cache.py
@@ -18,26 +18,22 @@ from cloud_autopkg_runner.settings import Settings
 @pytest_asyncio.fixture
 async def gcs_cache() -> Generator[AsyncGCSCache, Any, None]:
     """Fixture to create an AsyncGCSCache instance with mocks."""
-    with (
-        patch.object(Settings, "_instance", None),
-        patch.object(AsyncGCSCache, "_instance", None),
-    ):
-        settings = Settings()
-        settings.cloud_container_name = "test-container"
-        settings.cache_file = "metadata_cache.json"
+    settings = Settings()
+    settings.cloud_container_name = "test-container"
+    settings.cache_file = "metadata_cache.json"
 
-        cache = AsyncGCSCache()
-        cache._client = AsyncMock(spec=Client)
-        mock_bucket = MagicMock(spec=Bucket)
-        cache._client.bucket.return_value = mock_bucket
-        mock_blob = MagicMock(spec=Blob)
-        mock_bucket.blob.return_value = mock_blob
-        mock_blob.download_as_bytes = MagicMock(
-            return_value=json.dumps({"recipe1": {"timestamp": "test"}}).encode("utf-8")
-        )
+    cache = AsyncGCSCache()
+    cache._client = AsyncMock(spec=Client)
+    mock_bucket = MagicMock(spec=Bucket)
+    cache._client.bucket.return_value = mock_bucket
+    mock_blob = MagicMock(spec=Blob)
+    mock_bucket.blob.return_value = mock_blob
+    mock_blob.download_as_bytes = MagicMock(
+        return_value=json.dumps({"recipe1": {"timestamp": "test"}}).encode("utf-8")
+    )
 
-        yield cache
-        await cache.close()
+    yield cache
+    await cache.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cache/test_json_cache.py
+++ b/tests/unit/cache/test_json_cache.py
@@ -17,16 +17,12 @@ async def json_cache(tmp_path: Path) -> Generator[AsyncJsonFileCache, Any, None]
     cache_file = tmp_path / "metadata_cache.json"
     cache_file.write_text(json.dumps({"recipe1": {"timestamp": "test"}}))
 
-    with (
-        patch.object(Settings, "_instance", None),
-        patch.object(AsyncJsonFileCache, "_instance", None),
-    ):
-        settings = Settings()
-        settings.cache_file = cache_file
+    settings = Settings()
+    settings.cache_file = cache_file
 
-        cache = AsyncJsonFileCache()
-        yield cache
-        await cache.close()
+    cache = AsyncJsonFileCache()
+    yield cache
+    await cache.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cache/test_s3_cache.py
+++ b/tests/unit/cache/test_s3_cache.py
@@ -15,11 +15,7 @@ from cloud_autopkg_runner.cache.s3_cache import AsyncS3Cache
 @pytest_asyncio.fixture
 async def s3_cache() -> Generator[AsyncS3Cache, Any, None]:
     """Fixture to create an AsyncS3Cache instance with mocks."""
-    with (
-        patch.object(Settings, "_instance", None),
-        patch.object(AsyncS3Cache, "_instance", None),
-        patch("cloud_autopkg_runner.cache.s3_cache.boto3.Session"),
-    ):
+    with patch("cloud_autopkg_runner.cache.s3_cache.boto3.Session"):
         settings = Settings()
         settings.cloud_container_name = "test-bucket"
         settings.cache_file = "metadata_cache.json"

--- a/tests/unit/cache/test_sqlite_cache.py
+++ b/tests/unit/cache/test_sqlite_cache.py
@@ -35,16 +35,12 @@ async def sqlite_cache(tmp_path: Path) -> Generator[AsyncSQLiteCache, Any, None]
     conn.commit()
     conn.close()
 
-    with (
-        patch.object(Settings, "_instance", None),
-        patch.object(AsyncSQLiteCache, "_instance", None),
-    ):
-        settings = Settings()
-        settings.cache_file = cache_file
+    settings = Settings()
+    settings.cache_file = cache_file
 
-        cache = AsyncSQLiteCache()
-        yield cache
-        await cache.close()
+    cache = AsyncSQLiteCache()
+    yield cache
+    await cache.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,16 +1,68 @@
+import asyncio
+import importlib
 from collections.abc import Generator
 
 import pytest
 
 from cloud_autopkg_runner import Settings
+from cloud_autopkg_runner.metadata_cache import PluginManager
+
+# Cache backends live behind optional extras, so they are resolved by name and
+# skipped when the extra is not installed.
+_CACHE_SINGLETONS: tuple[tuple[str, str], ...] = (
+    ("cloud_autopkg_runner.cache.json_cache", "AsyncJsonFileCache"),
+    ("cloud_autopkg_runner.cache.sqlite_cache", "AsyncSQLiteCache"),
+    ("cloud_autopkg_runner.cache.s3_cache", "AsyncS3Cache"),
+    ("cloud_autopkg_runner.cache.gcs_cache", "AsyncGCSCache"),
+    ("cloud_autopkg_runner.cache.azure_blob_cache", "AsyncAzureBlobCache"),
+)
+
+
+def singleton_classes() -> list[type]:
+    """Collect every singleton class that leaks state between tests.
+
+    Returns:
+        The singleton classes available in this environment.
+    """
+    classes: list[type] = [Settings, PluginManager]
+
+    for module_name, class_name in _CACHE_SINGLETONS:
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        classes.append(getattr(module, class_name))
+
+    return classes
+
+
+def _reset_singletons() -> None:
+    """Discard every cached singleton instance and its class-level lock."""
+    for cls in singleton_classes():
+        cls._instance = None
+
+        # Locks bind to the first event loop that contends for them, which
+        # would outlive the per-test loop.
+        if isinstance(getattr(cls, "_lock", None), asyncio.Lock):
+            cls._lock = asyncio.Lock()
 
 
 @pytest.fixture(autouse=True)
 def reset_singletons() -> Generator[None, None, None]:
-    """Fixture to reset the singleton instances before each test.
+    """Fixture to reset the singleton instances around each test.
 
-    This ensures that each test gets a clean, independent instance of each singleton,
-    preventing test contamination.
+    Settings, PluginManager, and every cache backend cache their first
+    instance for the lifetime of the process. Each cache backend also latches
+    onto the cache file it was constructed with, so without this the first
+    test to touch the cache pins that file and its contents for every test
+    that follows.
+
+    Resetting before as well as after keeps a test from inheriting state built
+    during collection or left behind by a test that errored.
+
+    Yields:
+        None.
     """
+    _reset_singletons()
     yield
-    Settings._instance = None
+    _reset_singletons()

--- a/tests/unit/test_metadata_cache.py
+++ b/tests/unit/test_metadata_cache.py
@@ -43,85 +43,42 @@ def test_get_cache_plugin() -> None:
         mock_get_plugin.assert_called_once()
 
 
-def test_plugin_manager_load_plugin_default() -> None:
-    """Test successful plugin loading."""
+@pytest.mark.parametrize(
+    ("plugin_name", "expected_type", "extra_settings"),
+    [
+        ("default", AsyncJsonFileCache, {}),
+        ("json", AsyncJsonFileCache, {}),
+        ("sqlite", AsyncSQLiteCache, {"cache_file": "cache_file.sqlite"}),
+        ("s3", AsyncS3Cache, {"cloud_container_name": "fake_bucket"}),
+        ("gcs", AsyncGCSCache, {"cloud_container_name": "fake_bucket"}),
+        (
+            "azure",
+            AsyncAzureBlobCache,
+            {
+                "cloud_container_name": "fake_bucket",
+                "azure_account_url": "https://fake_account_url",
+            },
+        ),
+    ],
+    ids=["default", "json", "sqlite", "s3", "gcs", "azure"],
+)
+def test_plugin_manager_load_plugin(
+    plugin_name: str,
+    expected_type: type[MetadataCachePlugin],
+    extra_settings: dict[str, str],
+) -> None:
+    """Test that each entry point resolves to its backend."""
     plugin_manager = PluginManager()
+
     settings = Settings()
-    settings.cache_plugin = "default"
+    settings.cache_plugin = plugin_name
     settings.cache_file = "cache_file.json"
+    for name, value in extra_settings.items():
+        setattr(settings, name, value)
 
     plugin_manager.load_plugin()
 
-    assert isinstance(plugin_manager.plugin, AsyncJsonFileCache)
-    assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
-
-
-def test_plugin_manager_load_plugin_json() -> None:
-    """Test successful plugin loading."""
-    plugin_manager = PluginManager()
-    settings = Settings()
-    settings.cache_plugin = "json"
-    settings.cache_file = "cache_file.json"
-
-    plugin_manager.load_plugin()
-
-    assert isinstance(plugin_manager.plugin, AsyncJsonFileCache)
-    assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
-
-
-def test_plugin_manager_load_plugin_azure() -> None:
-    """Test successful plugin loading."""
-    plugin_manager = PluginManager()
-    settings = Settings()
-    settings.cache_plugin = "azure"
-    settings.cache_file = "cache_file.json"
-    settings.cloud_container_name = "fake_bucket"
-    settings.azure_account_url = "https://fake_account_url"
-
-    plugin_manager.load_plugin()
-
-    assert isinstance(plugin_manager.plugin, AsyncAzureBlobCache)
-    assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
-
-
-def test_plugin_manager_load_plugin_gcs() -> None:
-    """Test successful plugin loading."""
-    plugin_manager = PluginManager()
-    settings = Settings()
-    settings.cache_plugin = "gcs"
-    settings.cache_file = "cache_file.json"
-    settings.cloud_container_name = "fake_bucket"
-
-    plugin_manager.load_plugin()
-
-    assert isinstance(plugin_manager.plugin, AsyncGCSCache)
-    assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
-
-
-def test_plugin_manager_load_plugin_s3() -> None:
-    """Test successful plugin loading."""
-    plugin_manager = PluginManager()
-    settings = Settings()
-    settings.cache_plugin = "s3"
-    settings.cache_file = "cache_file.json"
-    settings.cloud_container_name = "fake_bucket"
-
-    plugin_manager.load_plugin()
-
-    assert isinstance(plugin_manager.plugin, AsyncS3Cache)
-    assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
-
-
-def test_plugin_manager_load_plugin_sqlite() -> None:
-    """Test successful plugin loading."""
-    plugin_manager = PluginManager()
-    settings = Settings()
-    settings.cache_plugin = "sqlite"
-    settings.cache_file = "cache_file.sqlite"
-
-    plugin_manager.load_plugin()
-
-    assert isinstance(plugin_manager.plugin, AsyncSQLiteCache)
+    assert isinstance(plugin_manager.plugin, expected_type)
     assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
 
 

--- a/tests/unit/test_metadata_cache.py
+++ b/tests/unit/test_metadata_cache.py
@@ -1,7 +1,5 @@
 """Tests for the metadata_cache module."""
 
-from collections.abc import Generator
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,16 +18,6 @@ from cloud_autopkg_runner.metadata_cache import (
 )
 
 
-@pytest.fixture
-def plugin_manager() -> Generator[PluginManager, Any, None]:
-    """Fixture that yields PluginManager and removes _instance after."""
-    with (
-        patch.object(Settings, "_instance", None),
-        patch.object(PluginManager, "_instance", None),
-    ):
-        yield PluginManager()
-
-
 def test_plugin_manager_singleton() -> None:
     """Test that PluginManager is a singleton."""
     plugin_manager1 = PluginManager()
@@ -37,8 +25,9 @@ def test_plugin_manager_singleton() -> None:
     assert plugin_manager1 is plugin_manager2
 
 
-def test_plugin_manager_get_plugin(plugin_manager: PluginManager) -> None:
+def test_plugin_manager_get_plugin() -> None:
     """Test that PluginManager returns the correct plugin."""
+    plugin_manager = PluginManager()
     plugin_manager.plugin = MagicMock()
     assert plugin_manager.get_plugin() == plugin_manager.plugin
 
@@ -54,8 +43,9 @@ def test_get_cache_plugin() -> None:
         mock_get_plugin.assert_called_once()
 
 
-def test_plugin_manager_load_plugin_default(plugin_manager: PluginManager) -> None:
+def test_plugin_manager_load_plugin_default() -> None:
     """Test successful plugin loading."""
+    plugin_manager = PluginManager()
     settings = Settings()
     settings.cache_plugin = "default"
     settings.cache_file = "cache_file.json"
@@ -66,8 +56,9 @@ def test_plugin_manager_load_plugin_default(plugin_manager: PluginManager) -> No
     assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
 
 
-def test_plugin_manager_load_plugin_json(plugin_manager: PluginManager) -> None:
+def test_plugin_manager_load_plugin_json() -> None:
     """Test successful plugin loading."""
+    plugin_manager = PluginManager()
     settings = Settings()
     settings.cache_plugin = "json"
     settings.cache_file = "cache_file.json"
@@ -78,8 +69,9 @@ def test_plugin_manager_load_plugin_json(plugin_manager: PluginManager) -> None:
     assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
 
 
-def test_plugin_manager_load_plugin_azure(plugin_manager: PluginManager) -> None:
+def test_plugin_manager_load_plugin_azure() -> None:
     """Test successful plugin loading."""
+    plugin_manager = PluginManager()
     settings = Settings()
     settings.cache_plugin = "azure"
     settings.cache_file = "cache_file.json"
@@ -92,8 +84,9 @@ def test_plugin_manager_load_plugin_azure(plugin_manager: PluginManager) -> None
     assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
 
 
-def test_plugin_manager_load_plugin_gcs(plugin_manager: PluginManager) -> None:
+def test_plugin_manager_load_plugin_gcs() -> None:
     """Test successful plugin loading."""
+    plugin_manager = PluginManager()
     settings = Settings()
     settings.cache_plugin = "gcs"
     settings.cache_file = "cache_file.json"
@@ -105,8 +98,9 @@ def test_plugin_manager_load_plugin_gcs(plugin_manager: PluginManager) -> None:
     assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
 
 
-def test_plugin_manager_load_plugin_s3(plugin_manager: PluginManager) -> None:
+def test_plugin_manager_load_plugin_s3() -> None:
     """Test successful plugin loading."""
+    plugin_manager = PluginManager()
     settings = Settings()
     settings.cache_plugin = "s3"
     settings.cache_file = "cache_file.json"
@@ -118,8 +112,9 @@ def test_plugin_manager_load_plugin_s3(plugin_manager: PluginManager) -> None:
     assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
 
 
-def test_plugin_manager_load_plugin_sqlite(plugin_manager: PluginManager) -> None:
+def test_plugin_manager_load_plugin_sqlite() -> None:
     """Test successful plugin loading."""
+    plugin_manager = PluginManager()
     settings = Settings()
     settings.cache_plugin = "sqlite"
     settings.cache_file = "cache_file.sqlite"
@@ -130,10 +125,9 @@ def test_plugin_manager_load_plugin_sqlite(plugin_manager: PluginManager) -> Non
     assert isinstance(plugin_manager.plugin, MetadataCachePlugin)
 
 
-def test_plugin_manager_load_plugin_error_handling(
-    plugin_manager: PluginManager,
-) -> None:
+def test_plugin_manager_load_plugin_error_handling() -> None:
     """Test that PluginManager handles plugin loading errors correctly."""
+    plugin_manager = PluginManager()
     settings = Settings()
     settings.cache_plugin = "nonexistent"
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,26 +1,11 @@
 """Tests for the settings module."""
 
-from collections.abc import Generator
 from pathlib import Path
-from typing import Any
-from unittest.mock import patch
 
 import pytest
 
 from cloud_autopkg_runner import Settings
 from cloud_autopkg_runner.exceptions import SettingsValidationError
-
-
-@pytest.fixture
-def settings() -> Generator[Settings, Any, None]:
-    """Fixture to get the settings instance.
-
-    Returns:
-        Settings: A new instance of the Settings class.
-    """
-    with patch.object(Settings, "_instance", None):
-        instance = Settings()
-        yield instance
 
 
 def test_singleton_pattern() -> None:
@@ -30,8 +15,9 @@ def test_singleton_pattern() -> None:
     assert settings1 is settings2
 
 
-def test_attribute_access(settings: Settings) -> None:
+def test_attribute_access() -> None:
     """Test getting and setting each attribute of the Settings class."""
+    settings = Settings()
     assert isinstance(settings.cache_file, str)
     assert isinstance(settings.log_file, Path | None)
     assert isinstance(settings.max_concurrency, int)
@@ -42,15 +28,17 @@ def test_attribute_access(settings: Settings) -> None:
     assert isinstance(settings.input_variables, dict)
 
 
-def test_cache_file_setter(settings: Settings) -> None:
+def test_cache_file_setter() -> None:
     """Test setting the cache_file attribute with a Path object."""
+    settings = Settings()
     new_cache_file = "new_cache.json"
     settings.cache_file = new_cache_file
     assert settings.cache_file == new_cache_file
 
 
-def test_log_file_setter(tmp_path: Path, settings: Settings) -> None:
+def test_log_file_setter(tmp_path: Path) -> None:
     """Test setting the log_file attribute with a Path object or None."""
+    settings = Settings()
     new_log_file = tmp_path / "new_log.log"
     settings.log_file = new_log_file
     assert settings.log_file == new_log_file
@@ -62,32 +50,37 @@ def test_log_file_setter(tmp_path: Path, settings: Settings) -> None:
     assert settings.log_file is None
 
 
-def test_log_format_setter_text(settings: Settings) -> None:
+def test_log_format_setter_text() -> None:
     """Test setting the cache_file attribute with a Path object."""
+    settings = Settings()
     settings.cache_file = "text"
     assert settings.cache_file == "text"
 
 
-def test_log_format_setter_json(settings: Settings) -> None:
+def test_log_format_setter_json() -> None:
     """Test setting the cache_file attribute with a Path object."""
+    settings = Settings()
     settings.cache_file = "json"
     assert settings.cache_file == "json"
 
 
-def test_log_format_validation(settings: Settings) -> None:
+def test_log_format_validation() -> None:
     """Test setting the verbosity_level attribute with invalid values."""
+    settings = Settings()
     with pytest.raises(SettingsValidationError):
         settings.log_format = "invalid"
 
 
-def test_max_concurrency_setter(settings: Settings) -> None:
+def test_max_concurrency_setter() -> None:
     """Test setting the max_concurrency attribute with a valid integer."""
+    settings = Settings()
     settings.max_concurrency = 20
     assert settings.max_concurrency == 20
 
 
-def test_max_concurrency_setter_validation(settings: Settings) -> None:
+def test_max_concurrency_setter_validation() -> None:
     """Test setting the max_concurrency attribute with invalid values."""
+    settings = Settings()
     with pytest.raises(SettingsValidationError):
         settings.max_concurrency = 0
 
@@ -98,8 +91,9 @@ def test_max_concurrency_setter_validation(settings: Settings) -> None:
         settings.max_concurrency = "invalid"
 
 
-def test_report_dir_setter(tmp_path: Path, settings: Settings) -> None:
+def test_report_dir_setter(tmp_path: Path) -> None:
     """Test setting the report_dir attribute with a Path object."""
+    settings = Settings()
     new_report_dir = tmp_path / "new_reports"
     settings.report_dir = new_report_dir
     assert settings.report_dir == new_report_dir
@@ -108,14 +102,16 @@ def test_report_dir_setter(tmp_path: Path, settings: Settings) -> None:
     assert settings.report_dir == new_report_dir
 
 
-def test_verbosity_level_setter(settings: Settings) -> None:
+def test_verbosity_level_setter() -> None:
     """Test setting the verbosity_level attribute with a valid integer."""
+    settings = Settings()
     settings.verbosity_level = 3
     assert settings.verbosity_level == 3
 
 
-def test_verbosity_level_setter_validation(settings: Settings) -> None:
+def test_verbosity_level_setter_validation() -> None:
     """Test setting the verbosity_level attribute with invalid values."""
+    settings = Settings()
     with pytest.raises(SettingsValidationError):
         settings.verbosity_level = -1
 
@@ -139,10 +135,9 @@ def test_verbosity_level_setter_validation(settings: Settings) -> None:
         (2, -4, 0),
     ],
 )
-def test_verbosity_int(
-    level: int, delta: int, expected: str, settings: Settings
-) -> None:
+def test_verbosity_int(level: int, delta: int, expected: str) -> None:
     """Test the verbosity_str method with different delta values."""
+    settings = Settings()
     settings.verbosity_level = level
     assert settings.verbosity_int(delta) == expected
 
@@ -163,16 +158,16 @@ def test_verbosity_int(
         (2, -4, ""),
     ],
 )
-def test_verbosity_str(
-    level: int, delta: int, expected: str, settings: Settings
-) -> None:
+def test_verbosity_str(level: int, delta: int, expected: str) -> None:
     """Test the verbosity_str method with different delta values."""
+    settings = Settings()
     settings.verbosity_level = level
     assert settings.verbosity_str(delta) == expected
 
 
-def test_convert_to_path(settings: Settings) -> None:
+def test_convert_to_path() -> None:
     """Test the _convert_to_path method."""
+    settings = Settings()
     test_path = Path("/test/path")
     assert settings._convert_to_path("/test/path") == test_path
     assert settings._convert_to_path(test_path) == test_path
@@ -189,9 +184,10 @@ def test_convert_to_path(settings: Settings) -> None:
     ],
 )
 def test_pre_processors_setter(
-    input_value: str | list[str], expected_output: list[str], settings: Settings
+    input_value: str | list[str], expected_output: list[str]
 ) -> None:
     """Test setting the pre_processors attribute with various inputs."""
+    settings = Settings()
     settings.pre_processors = input_value
     assert settings.pre_processors == expected_output
 
@@ -207,9 +203,10 @@ def test_pre_processors_setter(
     ],
 )
 def test_post_processors_setter(
-    input_value: str | list[str], expected_output: list[str], settings: Settings
+    input_value: str | list[str], expected_output: list[str]
 ) -> None:
     """Test setting the post_processors attribute with various inputs."""
+    settings = Settings()
     settings.post_processors = input_value
     assert settings.post_processors == expected_output
 
@@ -223,8 +220,9 @@ def test_post_processors_setter(
     ],
 )
 def test_input_variables_setter(
-    input_value: dict[str, str], expected_output: dict[str, str], settings: Settings
+    input_value: dict[str, str], expected_output: dict[str, str]
 ) -> None:
     """Test setting the override_variables attribute with various dicts."""
+    settings = Settings()
     settings.input_variables = input_value
     assert settings.input_variables == expected_output

--- a/tests/unit/test_singleton_isolation.py
+++ b/tests/unit/test_singleton_isolation.py
@@ -1,0 +1,87 @@
+"""Tests that singleton state does not leak between tests.
+
+Every test in this module deliberately builds singleton state that would be
+visible to the tests that follow it. They pass in isolation whether or not the
+autouse reset in conftest is in place; they only fail as a group, and only
+when that reset is missing. Run the module as a whole to exercise it.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cloud_autopkg_runner import Settings
+from cloud_autopkg_runner.cache.json_cache import AsyncJsonFileCache
+from cloud_autopkg_runner.metadata_cache import PluginManager, get_cache_plugin
+
+
+def _write_cache(cache_file: Path, recipe_name: str) -> None:
+    """Write a single-entry metadata cache to disk.
+
+    Args:
+        cache_file: Where to write the cache.
+        recipe_name: The recipe name to record in it.
+    """
+    cache_file.write_text(
+        json.dumps({recipe_name: {"timestamp": "foo", "metadata": []}})
+    )
+
+
+@pytest.mark.asyncio
+async def test_cache_plugin_reads_first_configured_file(tmp_path: Path) -> None:
+    """Load a cache so a later test would inherit it without isolation."""
+    cache_file = tmp_path / "first.json"
+    _write_cache(cache_file, "FirstRecipe")
+
+    settings = Settings()
+    settings.cache_file = str(cache_file)
+
+    assert await get_cache_plugin().load() == {
+        "FirstRecipe": {"timestamp": "foo", "metadata": []}
+    }
+
+
+@pytest.mark.asyncio
+async def test_cache_plugin_reads_second_configured_file(tmp_path: Path) -> None:
+    """A different cache file must be honored, not the previous test's."""
+    cache_file = tmp_path / "second.json"
+    _write_cache(cache_file, "SecondRecipe")
+
+    settings = Settings()
+    settings.cache_file = str(cache_file)
+
+    assert await get_cache_plugin().load() == {
+        "SecondRecipe": {"timestamp": "foo", "metadata": []}
+    }
+
+
+def test_settings_starts_from_defaults() -> None:
+    """Settings must not carry values assigned by an earlier test."""
+    assert Settings().cache_file == "metadata_cache.json"
+    assert Settings().max_concurrency == 10
+
+    Settings().cache_file = "mutated.json"
+    Settings().max_concurrency = 99
+
+
+def test_settings_defaults_survive_previous_mutation() -> None:
+    """The mutations made by the previous test must not be visible here."""
+    assert Settings().cache_file == "metadata_cache.json"
+    assert Settings().max_concurrency == 10
+
+
+def test_plugin_manager_starts_unresolved() -> None:
+    """PluginManager must not reuse a plugin resolved by an earlier test."""
+    Settings().cache_plugin = "sqlite"
+    manager = PluginManager()
+
+    assert type(manager.get_plugin()).__name__ == "AsyncSQLiteCache"
+
+
+def test_plugin_manager_resolves_the_current_plugin() -> None:
+    """A later test choosing a different backend must actually get it."""
+    Settings().cache_plugin = "json"
+    manager = PluginManager()
+
+    assert isinstance(manager.get_plugin(), AsyncJsonFileCache)


### PR DESCRIPTION
`conftest` reset `Settings` between tests but nothing else.

### Unit suite

The first test to touch the cache decided what every later test saw. Nothing failed, because exactly one test exercised each of those paths. Adding a second test near them could fail in the confusing way where each test passes alone and the pair does not.

### Integration suite

Worse, because it was silently weakening tests that appeared to pass. Each `settings` fixture generates a container name unique to its test:

```python
settings.cloud_container_name = generate_unique_name("cloud-autopkg-test-s3")
```

But the backend that `Settings` names is a singleton, so the second test in a module received the plugin built for the first — still pointing at the previous container, still holding what that container had loaded, with `_is_loaded` already `True`. `test_retrieve_cache_file` was therefore asserting against data the previous test left in memory rather than anything the emulator returned. It passed because both tests share one `test_data` fixture, so the values matched by construction. All three modules have this shape.

### Changes

- One `tests/conftest.py` covering both suites, rather than a copy per suite. `tests/unit/conftest.py` moves up.
- Every singleton is reset around each test, before as well as after, so a test cannot inherit state built during collection or left by one that errored.
- Cache backends are resolved by name and skipped when their extra is not installed, so the suite still runs without the optional cloud dependencies.
- Class-level `asyncio.Lock`s are replaced too. They bind to the first event loop that *contends* for them, which outlives the per-test loop. Latent today because nothing contends; a concurrency test would weld one to a dead loop and every later test contending it would fail with `is bound to a different event loop`.
- Removed the per-fixture patching this replaces, including three manual `Settings._instance = None` teardowns in the integration fixtures. Two unit fixtures existed only to wrap that patching and are gone; a fixture returning a bare singleton implies an isolation it does not provide. The five cache fixtures stay, since they write cache files, install mocks, and close the backend on teardown.

### Validation

`test_singleton_isolation.py` covers the unit behavior. Each test deliberately builds state the next would observe, so the file passes test by test and only fails as a group when the reset is missing. Against the old conftest:

```
FAILED test_cache_plugin_reads_second_configured_file - assert {'FirstRecipe'...} == {'SecondRecipe'...}
FAILED test_plugin_manager_starts_unresolved - assert 'AsyncJsonFileCache' == 'AsyncSQLiteCache'
```

The integration change was validated offline by mirroring its fixture pattern against the json backend, which needs no emulator:

| | before | after |
|---|---|---|
| distinct plugin objects | `False` | `True` |
| distinct cache targets | `False` | `True` |
| test 1 data visible to test 2 | `True` | `False` |

411 unit tests pass, serially and under `-n auto`. All 6 integration tests still collect.

### Needs review against live emulators

`test_retrieve_cache_file` now genuinely round-trips through the emulator in all three modules, for the first time. If one fails, that is a bug the stale in-memory cache was masking rather than a regression from this change.
