### PR TITLE
Handle a zero-byte placeholder without raising

### DIFF
--- a/src/cloud_autopkg_runner/exceptions.py
+++ b/src/cloud_autopkg_runner/exceptions.py
@@ -58,6 +58,23 @@ InvalidCacheContents = InvalidCacheContentsError
 
 
 # File Contents
+class InvalidFileSizeError(AutoPkgRunnerError):
+    """Error class for handling an unusable file size.
+
+    This error is raised when a cached file size cannot describe a real
+    file, such as a negative byte count.
+    """
+
+    def __init__(self, file_path: Path, size: int) -> None:
+        """Initializes InvalidFileSizeError with the path and offending size.
+
+        Args:
+            file_path: The path to the file that would have been created.
+            size: The invalid size, in bytes.
+        """
+        super().__init__(f"Invalid file size {size} for {file_path}")
+
+
 class InvalidFileContentsError(AutoPkgRunnerError):
     """Base error class for handling invalid file contents.
 

--- a/src/cloud_autopkg_runner/file_utils.py
+++ b/src/cloud_autopkg_runner/file_utils.py
@@ -31,6 +31,7 @@ from cloud_autopkg_runner import (
     metadata_cache,
     recipe_finder,
 )
+from cloud_autopkg_runner.exceptions import InvalidFileSizeError
 from cloud_autopkg_runner.metadata_cache import DownloadMetadata
 
 
@@ -61,7 +62,7 @@ def _create_and_set_attrs(file_path: Path, metadata_cache: DownloadMetadata) -> 
 
 
 def _set_file_size(file_path: Path, size: int) -> None:
-    """Set a file to a specified size by writing a null byte at the end.
+    """Set a file to a specified size without writing that many bytes.
 
     Effectively replicates the behavior of `mkfile -n` on macOS. This function
     does not actually write `size` bytes of data, but rather sets the file's
@@ -70,11 +71,18 @@ def _set_file_size(file_path: Path, size: int) -> None:
 
     Args:
         file_path: The path to the file.
-        size: The desired size of the file in bytes.
+        size: The desired size of the file in bytes. Zero is valid and
+            produces an empty file.
+
+    Raises:
+        InvalidFileSizeError: If `size` is negative.
     """
+    size = int(size)
+    if size < 0:
+        raise InvalidFileSizeError(file_path, size)
+
     with file_path.open("wb") as f:
-        f.seek(int(size) - 1)
-        f.write(b"\0")
+        f.truncate(size)
 
 
 async def create_placeholder_files(
@@ -120,9 +128,17 @@ async def create_placeholder_files(
                     recipe_name,
                 )
                 continue
-            if not the_cache.get("file_size"):
+            file_size = the_cache.get("file_size")
+            if file_size is None:
                 logger.warning(
                     "Skipping file creation: Missing 'file_size' in %s cache",
+                    recipe_name,
+                )
+                continue
+            if file_size < 0:
+                logger.warning(
+                    "Skipping file creation: Negative 'file_size' (%s) in %s cache",
+                    file_size,
                     recipe_name,
                 )
                 continue

--- a/src/cloud_autopkg_runner/file_utils.py
+++ b/src/cloud_autopkg_runner/file_utils.py
@@ -142,6 +142,15 @@ async def create_placeholder_files(
                     recipe_name,
                 )
                 continue
+            if file_size == 0:
+                # URLDownloader.clear_zero_file() deletes any empty file before
+                # it reads the xattrs, so an empty placeholder buys nothing.
+                logger.warning(
+                    "Skipping file creation: Empty 'file_size' in %s cache. "
+                    "AutoPkg discards empty downloads, so it will fetch this again.",
+                    recipe_name,
+                )
+                continue
 
             file_path = Path(the_cache.get("file_path", "")).expanduser()
             if file_path.exists():

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from cloud_autopkg_runner import Settings, file_utils
+from cloud_autopkg_runner.exceptions import InvalidFileSizeError
 from cloud_autopkg_runner.metadata_cache import MetadataCache
 
 
@@ -55,6 +56,106 @@ def metadata_cache(tmp_path: Path) -> MetadataCache:
             ],
         },
     }
+
+
+@pytest.mark.parametrize("size", [0, 1, 1024])
+def test_set_file_size(tmp_path: Path, size: int) -> None:
+    """A file is reported at the requested size, including zero."""
+    file_path = tmp_path / "placeholder.dmg"
+
+    file_utils._set_file_size(file_path, size)
+
+    assert file_path.stat().st_size == size
+
+
+def test_set_file_size_rejects_negative(tmp_path: Path) -> None:
+    """A negative size is rejected rather than raising a bare OSError."""
+    file_path = tmp_path / "placeholder.dmg"
+
+    with pytest.raises(InvalidFileSizeError):
+        file_utils._set_file_size(file_path, -1)
+
+
+def test_create_and_set_attrs_with_absent_file_size(
+    tmp_path: Path, mock_xattr: Any
+) -> None:
+    """Metadata with no file_size falls back to 0 without raising."""
+    file_path = tmp_path / "nested" / "placeholder.dmg"
+
+    file_utils._create_and_set_attrs(file_path, {"file_path": str(file_path)})
+
+    assert file_path.stat().st_size == 0
+    mock_xattr.setxattr.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_placeholder_files_with_zero_size(tmp_path: Path) -> None:
+    """A cached size of zero produces an empty placeholder, not a skip."""
+    settings = Settings()
+    settings.cache_file = tmp_path / "metadata_cache.json"
+    file_path = tmp_path / "path/to/empty.dmg"
+    settings.cache_file.write_text(
+        json.dumps(
+            {
+                "Recipe1": {
+                    "timestamp": "foo",
+                    "metadata": [{"file_path": str(file_path), "file_size": 0}],
+                }
+            }
+        )
+    )
+
+    with (
+        patch(
+            "cloud_autopkg_runner.autopkg_prefs.AutoPkgPrefs._get_preference_file_contents",
+            return_value={},
+        ),
+        patch(
+            "cloud_autopkg_runner.recipe_finder.RecipeFinder.possible_file_names",
+            return_value=["Recipe1"],
+        ),
+    ):
+        await file_utils.create_placeholder_files(["Recipe1"])
+
+    assert file_path.exists()
+    assert file_path.stat().st_size == 0
+
+
+@pytest.mark.asyncio
+async def test_create_placeholder_files_skips_negative_size(tmp_path: Path) -> None:
+    """A corrupt negative size is skipped without failing the whole run."""
+    settings = Settings()
+    settings.cache_file = tmp_path / "metadata_cache.json"
+    bad_path = tmp_path / "path/to/bad.dmg"
+    good_path = tmp_path / "path/to/good.dmg"
+    settings.cache_file.write_text(
+        json.dumps(
+            {
+                "Recipe1": {
+                    "timestamp": "foo",
+                    "metadata": [
+                        {"file_path": str(bad_path), "file_size": -1},
+                        {"file_path": str(good_path), "file_size": 512},
+                    ],
+                }
+            }
+        )
+    )
+
+    with (
+        patch(
+            "cloud_autopkg_runner.autopkg_prefs.AutoPkgPrefs._get_preference_file_contents",
+            return_value={},
+        ),
+        patch(
+            "cloud_autopkg_runner.recipe_finder.RecipeFinder.possible_file_names",
+            return_value=["Recipe1"],
+        ),
+    ):
+        await file_utils.create_placeholder_files(["Recipe1"])
+
+    assert not bad_path.exists()
+    assert good_path.stat().st_size == 512
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+import xattr
 
 from cloud_autopkg_runner import Settings, file_utils
 from cloud_autopkg_runner.exceptions import InvalidFileSizeError
@@ -76,6 +77,42 @@ def test_set_file_size_rejects_negative(tmp_path: Path) -> None:
         file_utils._set_file_size(file_path, -1)
 
 
+def test_placeholder_satisfies_urldownloader(tmp_path: Path) -> None:
+    """A placeholder must survive the checks AutoPkg's URLDownloader makes.
+
+    URLDownloader deletes any empty file before reading its xattrs
+    (clear_zero_file), then reads the size and the etag/last-modified xattrs
+    to build its conditional request (produce_etag_headers). It never reads
+    the file's contents.
+    """
+    file_path = tmp_path / "GoogleChrome" / "googlechrome.dmg"
+    file_utils._create_and_set_attrs(
+        file_path,
+        {
+            "file_path": str(file_path),
+            "file_size": 219045888,
+            "etag": '"3f8a9c1d"',
+            "last_modified": "Wed, 21 Oct 2025 07:28:00 GMT",
+        },
+    )
+
+    # clear_zero_file() would delete anything empty.
+    assert file_path.stat().st_size != 0
+
+    # produce_etag_headers() reports this as existing_file_size.
+    assert file_path.stat().st_size == 219045888
+
+    # getxattr() looks the name up in listxattr() before reading it.
+    listed = xattr.listxattr(file_path)
+    assert "com.github.autopkg.etag" in listed
+    assert "com.github.autopkg.last-modified" in listed
+    assert xattr.getxattr(file_path, "com.github.autopkg.etag").decode() == '"3f8a9c1d"'
+    assert (
+        xattr.getxattr(file_path, "com.github.autopkg.last-modified").decode()
+        == "Wed, 21 Oct 2025 07:28:00 GMT"
+    )
+
+
 def test_create_and_set_attrs_with_absent_file_size(
     tmp_path: Path, mock_xattr: Any
 ) -> None:
@@ -89,8 +126,8 @@ def test_create_and_set_attrs_with_absent_file_size(
 
 
 @pytest.mark.asyncio
-async def test_create_placeholder_files_with_zero_size(tmp_path: Path) -> None:
-    """A cached size of zero produces an empty placeholder, not a skip."""
+async def test_create_placeholder_files_skips_zero_size(tmp_path: Path) -> None:
+    """A cached size of zero is skipped, since AutoPkg discards empty files."""
     settings = Settings()
     settings.cache_file = tmp_path / "metadata_cache.json"
     file_path = tmp_path / "path/to/empty.dmg"
@@ -117,8 +154,7 @@ async def test_create_placeholder_files_with_zero_size(tmp_path: Path) -> None:
     ):
         await file_utils.create_placeholder_files(["Recipe1"])
 
-    assert file_path.exists()
-    assert file_path.stat().st_size == 0
+    assert not file_path.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`_set_file_size` created its sparse placeholder by seeking to `size - 1` and writing a null byte. For a size of zero that seeks to `-1`:

```
OSError: [Errno 22] Invalid argument
```

`create_placeholder_files` never reached it, since it treats any falsy `file_size` as missing metadata and skips the entry. But `_create_and_set_attrs` defaults the size to `0` independently, so any other caller trips it.

### Changes

- `_set_file_size` uses `truncate`, which is the operation actually wanted here: it reports the size without writing the bytes, and accepts zero.
- Negative sizes cannot describe a file, so they raise `InvalidFileSizeError` naming the path and the size, rather than surfacing the same bare `Errno 22`.
- `create_placeholder_files` distinguishes a missing `file_size` from a negative one from an empty one, and says which it found. All three are skipped.

### Behavior against URLDownloader

Verified against the checks in [URLDownloader](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/URLDownloader.py) and `URLGetter.produce_etag_headers`, run verbatim against a real placeholder:

```
placeholder for a real download (cached file_size=219045888)
  survives clear_zero_file : True
  existing_file_size       : 219045888
  request headers          : {'If-None-Match': '"3f8a9c1d"',
                              'If-Modified-Since': 'Wed, 21 Oct 2025 07:28:00 GMT'}
  304 -> download_changed  : False
  size-match -> changed    : False
```

`URLDownloader` never reads the file's contents. It stats the file and reads the two xattrs, so a sparse placeholder is indistinguishable from a real download for its purposes.

Empty placeholders are therefore skipped rather than created: `clear_zero_file()` deletes any empty file before the xattrs are read, so writing one only adds a write and a delete before the download happens anyway.

### truncate vs. the previous seek+write

Compared directly across sizes 1, 2, 1024, 54321, 8 MiB and 1 GiB. `st_size`, content hash, all-zero contents, file mode, and the overwrite-an-existing-file case are identical. The one difference is allocation:

```
       54321  st_blocks       112  ->  0
     8388608  st_blocks     16384  ->  0
```

At 8 MiB the old implementation allocated the entire file, so the placeholder was not sparse at all in that range. `truncate` allocates nothing at any size. Never more disk than before, often much less.

### Testing

21 tests in `test_file_utils.py`, including one that pins the URLDownloader contract: non-empty size, size matching the cached value, and both xattrs resolvable through `listxattr`/`getxattr`. All the tests covering the fixed paths fail against the previous implementation with the original `OSError: [Errno 22]`.

419 unit tests pass, serially and under `-n auto`. `ruff check`, `ruff format --check`, and `pyright` are clean.

### Unrelated issue found while verifying

`URLDownloader` prefixes its xattr names with `user.` on Linux (`user.com.github.autopkg.etag`), while this project hardcodes the unprefixed form in both `file_utils.py` and `recipe.py`. On Linux the placeholders' xattrs would never be found and the conditional request would not be sent. Not addressed here.
