### PR TITLE
Test on three platforms, fix Linux xattr names, stop metadata errors failing recipes

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -64,11 +64,12 @@ jobs:
 
   unit-tests:
     name: 🧪 Unit Tests on ${{ matrix.os }} / Python ${{ matrix.python-version }}${{ matrix.experimental && ' (Experimental)' || '' }}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       statuses: write
     strategy:
+      fail-fast: false # Allows all matrix jobs to run even if one fails
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "hypothesis>=6.138.8",
-    "localstack>=4.7.0",
+    # localstack drives the integration suite, which only runs on Linux. It
+    # pulls in windows-curses, which has no wheel for every Python we test.
+    "localstack>=4.7.0; sys_platform != 'win32'",
     "pre-commit>=4.1.0",
     "pyright>=1.1.397",
     "pytest-asyncio>=0.26.0",
@@ -13,6 +15,9 @@ dev = [
     "pytest-xdist>=3.8.0",
     "ruff>=0.12.7",
     "types-boto3-lite[s3]>=1.40.70",
+    # Windows ships no time zone database, which Hypothesis needs when it
+    # generates aware datetimes.
+    "tzdata>=2025.1; sys_platform == 'win32'",
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 dependencies = [
     "pyyaml>=6.0.2",
     "tomli>=2.3.0; python_version<'3.11'",
-    "xattr>=1.1.4",
+    "xattr>=1.1.4; sys_platform != 'win32'",
 ]
 
 [project.scripts]

--- a/src/cloud_autopkg_runner/file_utils.py
+++ b/src/cloud_autopkg_runner/file_utils.py
@@ -43,6 +43,15 @@ from cloud_autopkg_runner.metadata_cache import DownloadMetadata
 _ENOATTR: int = getattr(errno, "ENOATTR", errno.ENODATA)
 _MISSING_ATTR_ERRNOS: frozenset[int] = frozenset({_ENOATTR, errno.ENODATA})
 
+# AutoPkg's URLDownloader prefixes its extended attribute names with "user."
+# on Linux, whose kernel only accepts attributes in a known namespace. These
+# must match `URLDownloader.clear_vars()` or the placeholders it reads and the
+# metadata we read back are looked up under names nothing ever wrote.
+_BUNDLE_ID = "com.github.autopkg"
+_XATTR_PREFIX = "user." if sys.platform.startswith("linux") else ""
+XATTR_ETAG = f"{_XATTR_PREFIX}{_BUNDLE_ID}.etag"
+XATTR_LAST_MODIFIED = f"{_XATTR_PREFIX}{_BUNDLE_ID}.last-modified"
+
 
 def _create_and_set_attrs(file_path: Path, metadata_cache: DownloadMetadata) -> None:
     """Create the file, set its size, and set extended attributes.
@@ -77,13 +86,13 @@ def _create_and_set_attrs(file_path: Path, metadata_cache: DownloadMetadata) -> 
     if metadata_cache.get("etag"):
         xattr.setxattr(  # pyright: ignore[reportUnknownMemberType]
             file_path,
-            "com.github.autopkg.etag",
+            XATTR_ETAG,
             metadata_cache.get("etag", "").encode("utf-8"),
         )
     if metadata_cache.get("last_modified"):
         xattr.setxattr(  # pyright: ignore[reportUnknownMemberType]
             file_path,
-            "com.github.autopkg.last-modified",
+            XATTR_LAST_MODIFIED,
             metadata_cache.get("last_modified", "").encode("utf-8"),
         )
 

--- a/src/cloud_autopkg_runner/file_utils.py
+++ b/src/cloud_autopkg_runner/file_utils.py
@@ -23,7 +23,11 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import cast
 
-import xattr  # pyright: ignore[reportMissingTypeStubs]
+if sys.platform == "win32":  # pragma: no cover - exercised on Windows only
+    # xattr publishes no Windows build; extended attributes do not exist there.
+    xattr = None
+else:
+    import xattr  # pyright: ignore[reportMissingTypeStubs]
 
 from cloud_autopkg_runner import (
     AutoPkgPrefs,
@@ -34,9 +38,24 @@ from cloud_autopkg_runner import (
 from cloud_autopkg_runner.exceptions import InvalidFileSizeError
 from cloud_autopkg_runner.metadata_cache import DownloadMetadata
 
+# macOS reports a missing extended attribute as ENOATTR, Linux as ENODATA.
+# ENOATTR is only defined on BSD-derived platforms.
+_ENOATTR: int = getattr(errno, "ENOATTR", errno.ENODATA)
+_MISSING_ATTR_ERRNOS: frozenset[int] = frozenset({_ENOATTR, errno.ENODATA})
+
 
 def _create_and_set_attrs(file_path: Path, metadata_cache: DownloadMetadata) -> None:
-    """Create the file, set its size, and set extended attributes."""
+    """Create the file, set its size, and set extended attributes.
+
+    On platforms without extended attribute support the file is still created
+    at the cached size, but the etag and last-modified attributes are skipped.
+
+    Args:
+        file_path: The path of the placeholder file to create.
+        metadata_cache: The cached download metadata to apply to the file.
+    """
+    logger = logging_config.get_logger(__name__)
+
     # Create parent directory if needed
     file_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -45,6 +64,14 @@ def _create_and_set_attrs(file_path: Path, metadata_cache: DownloadMetadata) -> 
 
     # Set file size
     _set_file_size(file_path, metadata_cache.get("file_size", 0))
+
+    if xattr is None:
+        logger.warning(
+            "Extended attributes are unsupported on this platform. "
+            "%s was created without its etag and last-modified metadata.",
+            file_path,
+        )
+        return
 
     # Set extended attributes
     if metadata_cache.get("etag"):
@@ -177,22 +204,33 @@ async def get_file_metadata(file_path: Path, attr: str) -> str | None:
 
     Returns:
         The decoded string representation of the extended attribute metadata,
-        or None if the attribute doesn't exist.
+        or None if the attribute doesn't exist or the platform has no
+        extended attribute support.
     """
+    # Bound to a local so the None check applies inside the thread's closure
+    xattr_module = xattr
+    if xattr_module is None:
+        logger = logging_config.get_logger(__name__)
+        logger.warning(
+            "Extended attributes are unsupported on this platform. "
+            "Cannot read %s from %s.",
+            attr,
+            file_path,
+        )
+        return None
+
     try:
         return await asyncio.to_thread(
             lambda: cast(
                 "bytes",
-                xattr.getxattr(  # pyright: ignore[reportUnknownMemberType]
+                xattr_module.getxattr(  # pyright: ignore[reportUnknownMemberType]
                     file_path, attr
                 ),
             ).decode()
         )
     except OSError as e:
-        # If attribute name is invalid, return None
-        if sys.platform == "darwin" and e.errno == errno.ENOATTR:
-            return None
-        if e.errno == errno.ENODATA:
+        # If the attribute is not set, report it as absent rather than failing
+        if e.errno in _MISSING_ATTR_ERRNOS:
             return None
 
         # Re-raise all other errors

--- a/src/cloud_autopkg_runner/file_utils.py
+++ b/src/cloud_autopkg_runner/file_utils.py
@@ -19,12 +19,13 @@ Functions:
 import asyncio
 import errno
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import cast
 
 if sys.platform == "win32":  # pragma: no cover - exercised on Windows only
-    # xattr publishes no Windows build; extended attributes do not exist there.
+    # xattr publishes no Windows build, so there is nothing to read or write
+    # extended attributes with there.
     xattr = None
 else:
     import xattr  # pyright: ignore[reportMissingTypeStubs]
@@ -56,8 +57,8 @@ XATTR_LAST_MODIFIED = f"{_XATTR_PREFIX}{_BUNDLE_ID}.last-modified"
 def _create_and_set_attrs(file_path: Path, metadata_cache: DownloadMetadata) -> None:
     """Create the file, set its size, and set extended attributes.
 
-    On platforms without extended attribute support the file is still created
-    at the cached size, but the etag and last-modified attributes are skipped.
+    Where extended attributes are unavailable, the file is still created at
+    the cached size, but the etag and last-modified attributes are skipped.
 
     Args:
         file_path: The path of the placeholder file to create.
@@ -76,25 +77,36 @@ def _create_and_set_attrs(file_path: Path, metadata_cache: DownloadMetadata) -> 
 
     if xattr is None:
         logger.warning(
-            "Extended attributes are unsupported on this platform. "
+            "Extended attributes are unavailable on this platform. "
             "%s was created without its etag and last-modified metadata.",
             file_path,
         )
         return
 
     # Set extended attributes
-    if metadata_cache.get("etag"):
-        xattr.setxattr(  # pyright: ignore[reportUnknownMemberType]
+    try:
+        if metadata_cache.get("etag"):
+            xattr.setxattr(  # pyright: ignore[reportUnknownMemberType]
+                file_path,
+                XATTR_ETAG,
+                metadata_cache.get("etag", "").encode("utf-8"),
+            )
+        if metadata_cache.get("last_modified"):
+            xattr.setxattr(  # pyright: ignore[reportUnknownMemberType]
+                file_path,
+                XATTR_LAST_MODIFIED,
+                metadata_cache.get("last_modified", "").encode("utf-8"),
+            )
+    except OSError as e:
+        # A file system that rejects extended attributes leaves a placeholder
+        # AutoPkg will re-download, which beats failing every other recipe
+        logger.warning(
+            "Could not set extended attributes on %s: %s. "
+            "AutoPkg will download this file again.",
             file_path,
-            XATTR_ETAG,
-            metadata_cache.get("etag", "").encode("utf-8"),
+            e,
         )
-    if metadata_cache.get("last_modified"):
-        xattr.setxattr(  # pyright: ignore[reportUnknownMemberType]
-            file_path,
-            XATTR_LAST_MODIFIED,
-            metadata_cache.get("last_modified", "").encode("utf-8"),
-        )
+        logger.debug("Setting extended attributes failed", exc_info=True)
 
 
 def _set_file_size(file_path: Path, size: int) -> None:
@@ -121,6 +133,36 @@ def _set_file_size(file_path: Path, size: int) -> None:
         f.truncate(size)
 
 
+def _report_placeholder_results(
+    task_paths: Sequence[Path], results: Sequence[BaseException | None]
+) -> None:
+    """Report the placeholder files that could not be written.
+
+    A placeholder that cannot be written costs a download rather than
+    correctness, so a file system error is reported and the remaining
+    placeholders stand. Anything else is left for the caller to handle.
+
+    Args:
+        task_paths: The placeholder paths, in the order they were scheduled.
+        results: What each of those tasks returned or raised, in the same order.
+
+    Raises:
+        BaseException: Whatever a task raised, unless it was an OSError.
+    """
+    logger = logging_config.get_logger(__name__)
+
+    for path, result in zip(task_paths, results, strict=True):
+        if isinstance(result, OSError):
+            logger.warning(
+                "Could not create placeholder %s: %s. "
+                "AutoPkg will download this file again.",
+                path,
+                result,
+            )
+        elif isinstance(result, BaseException):
+            raise result
+
+
 async def create_placeholder_files(
     recipe_list: Iterable[str], autopkg_prefs: AutoPkgPrefs | None = None
 ) -> None:
@@ -145,6 +187,7 @@ async def create_placeholder_files(
 
     cache = await metadata_cache.get_cache_plugin().load()
     tasks: list[asyncio.Task[None]] = []
+    task_paths: list[Path] = []
 
     possible_names: set[str] = set()
     for recipe_name in recipe_list:
@@ -198,9 +241,12 @@ async def create_placeholder_files(
                 asyncio.to_thread(_create_and_set_attrs, file_path, the_cache)
             )
             tasks.append(task)
+            task_paths.append(file_path)
 
     # Await all the tasks
-    await asyncio.gather(*tasks)
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    _report_placeholder_results(task_paths, results)
+
     logger.debug("Placeholder files created.")
 
 
@@ -213,15 +259,17 @@ async def get_file_metadata(file_path: Path, attr: str) -> str | None:
 
     Returns:
         The decoded string representation of the extended attribute metadata,
-        or None if the attribute doesn't exist or the platform has no
-        extended attribute support.
+        or None if the attribute is not set on the file, if the attribute
+        cannot be read, or if there is no xattr module on this platform to
+        read it with. Metadata that cannot be read costs a re-download on the
+        next run, which is not worth failing over.
     """
     # Bound to a local so the None check applies inside the thread's closure
     xattr_module = xattr
     if xattr_module is None:
         logger = logging_config.get_logger(__name__)
         logger.warning(
-            "Extended attributes are unsupported on this platform. "
+            "Extended attributes are unavailable on this platform. "
             "Cannot read %s from %s.",
             attr,
             file_path,
@@ -238,12 +286,16 @@ async def get_file_metadata(file_path: Path, attr: str) -> str | None:
             ).decode()
         )
     except OSError as e:
-        # If the attribute is not set, report it as absent rather than failing
+        # An unset attribute is the ordinary case, and not worth reporting
         if e.errno in _MISSING_ATTR_ERRNOS:
             return None
 
-        # Re-raise all other errors
-        raise
+        # Anything else - a file system without extended attribute support,
+        # an I/O error - leaves the value unknown rather than the run broken
+        logger = logging_config.get_logger(__name__)
+        logger.warning("Could not read %s from %s: %s", attr, file_path, e)
+        logger.debug("Reading %s failed", attr, exc_info=True)
+        return None
 
 
 async def get_file_size(file_path: Path) -> int:

--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -488,11 +488,16 @@ class Recipe:
             A `RecipeCache` dictionary containing a "timestamp" (`str`) and
             a `list` of `DownloadMetadata` dictionaries, one for each
             downloaded item for which metadata was successfully retrieved.
+            Items whose metadata could not be read are left out, so the next
+            run downloads them again.
         """
         download_paths: list[str] = self._extract_download_paths(download_items)
-        metadata_list: list[DownloadMetadata] = await asyncio.gather(
+        results = await asyncio.gather(
             *[self._get_metadata_for_item(path) for path in download_paths]
         )
+        metadata_list: list[DownloadMetadata] = [
+            item for item in results if item is not None
+        ]
 
         return {
             "timestamp": str(datetime.now(tz=timezone.utc)),
@@ -500,7 +505,7 @@ class Recipe:
         }
 
     @staticmethod
-    async def _get_metadata_for_item(downloaded_item: str) -> DownloadMetadata:
+    async def _get_metadata_for_item(downloaded_item: str) -> DownloadMetadata | None:
         """Retrieves metadata for a single downloaded item.
 
         This static asynchronous private method takes the `str` path to a
@@ -510,14 +515,20 @@ class Recipe:
         for the file's size. These operations are run concurrently using
         `asyncio.gather` for efficiency.
 
+        The recipe has already run and its downloads have already happened by
+        the time this is called, so a file that cannot be read costs a
+        re-download on the next run rather than failing this one.
+
         Args:
             downloaded_item: The `str` path to the downloaded item.
 
         Returns:
             A `DownloadMetadata` dictionary containing the ETag (`str` or `None`),
             file size (`int` or `None`), last modified date (`str` or `None`),
-            and the original file path (`str`) of the downloaded item.
+            and the original file path (`str`) of the downloaded item, or None
+            if the file could not be read.
         """
+        logger = logging_config.get_logger(__name__)
         downloaded_item_path: Path = Path(downloaded_item).expanduser()
 
         file_size_task = file_utils.get_file_size(downloaded_item_path)
@@ -529,9 +540,21 @@ class Recipe:
         )
 
         # Run the tasks concurrently and await all of them to finish
-        file_size, etag, last_modified = await asyncio.gather(
-            file_size_task, etag_task, last_modified_task
-        )
+        try:
+            file_size, etag, last_modified = await asyncio.gather(
+                file_size_task, etag_task, last_modified_task
+            )
+        except OSError as exc:
+            logger.warning(
+                "Could not read metadata for %s: %s. "
+                "The next run will download it again.",
+                downloaded_item,
+                exc,
+            )
+            logger.debug(
+                "Reading metadata for %s failed", downloaded_item, exc_info=True
+            )
+            return None
 
         output: DownloadMetadata = {
             "file_path": downloaded_item,

--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -522,10 +522,10 @@ class Recipe:
 
         file_size_task = file_utils.get_file_size(downloaded_item_path)
         etag_task = file_utils.get_file_metadata(
-            downloaded_item_path, "com.github.autopkg.etag"
+            downloaded_item_path, file_utils.XATTR_ETAG
         )
         last_modified_task = file_utils.get_file_metadata(
-            downloaded_item_path, "com.github.autopkg.last-modified"
+            downloaded_item_path, file_utils.XATTR_LAST_MODIFIED
         )
 
         # Run the tasks concurrently and await all of them to finish

--- a/tests/unit/test_autopkg_prefs.py
+++ b/tests/unit/test_autopkg_prefs.py
@@ -634,7 +634,7 @@ async def test_to_json_file() -> None:
         loaded_json = json.loads(content)
         assert loaded_json["GITHUB_TOKEN"] == "file_token_123"  # noqa: S105
         assert loaded_json["ANOTHER_KEY"] == ["item1", "item2"]
-        assert loaded_json["MUNKI_REPO"] == "/tmp/munki"
+        assert loaded_json["MUNKI_REPO"] == str(Path("/tmp/munki"))
         # Ensure default prefs are also included
         assert "CACHE_DIR" in loaded_json
         assert isinstance(loaded_json["CACHE_DIR"], str)

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -2,6 +2,7 @@
 
 import errno
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Any
@@ -138,6 +139,23 @@ def test_create_and_set_attrs_with_absent_file_size(
     mock_xattr.setxattr.assert_not_called()
 
 
+def test_create_and_set_attrs_survives_unwritable_attrs(
+    tmp_path: Path, mock_xattr: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A file system that rejects extended attributes must not fail the run."""
+    file_path = tmp_path / "placeholder.dmg"
+    mock_xattr.setxattr.side_effect = OSError(errno.ENOTSUP, "Operation not supported")
+
+    with caplog.at_level(logging.WARNING):
+        file_utils._create_and_set_attrs(
+            file_path,
+            {"file_path": str(file_path), "file_size": 1024, "etag": "test_etag"},
+        )
+
+    assert file_path.stat().st_size == 1024
+    assert "Could not set extended attributes" in caplog.text
+
+
 def test_create_and_set_attrs_without_xattr_support(tmp_path: Path) -> None:
     """Without extended attributes the placeholder is still created at size."""
     file_path = tmp_path / "placeholder.dmg"
@@ -252,6 +270,76 @@ async def test_create_placeholder_files(
 
 
 @pytest.mark.asyncio
+async def test_create_placeholder_files_survives_a_failure(
+    tmp_path: Path, metadata_cache: MetadataCache, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One unwritable placeholder must not cost the rest of the run."""
+    settings = Settings()
+    settings.cache_file = tmp_path / "metatadata_cache.json"
+    settings.cache_file.write_text(json.dumps(metadata_cache))
+    recipe_list = ["Recipe1", "Recipe2"]
+    file_path1 = tmp_path / "path/to/file1.dmg"
+    file_path2 = tmp_path / "path/to/file2.pkg"
+
+    real_create = file_utils._create_and_set_attrs
+
+    def fail_for_file1(file_path: Path, metadata: Any) -> None:
+        """Fail the first placeholder the way a read-only volume would."""
+        if file_path == file_path1:
+            raise OSError(errno.EROFS, "Read-only file system")
+        real_create(file_path, metadata)
+
+    with (
+        patch(
+            "cloud_autopkg_runner.autopkg_prefs.AutoPkgPrefs._get_preference_file_contents",
+            return_value={},
+        ),
+        patch(
+            "cloud_autopkg_runner.recipe_finder.RecipeFinder.possible_file_names",
+            return_value=recipe_list,
+        ),
+        patch(
+            "cloud_autopkg_runner.file_utils._create_and_set_attrs",
+            side_effect=fail_for_file1,
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        await file_utils.create_placeholder_files(recipe_list)
+
+    assert not file_path1.exists()
+    assert file_path2.stat().st_size == 2048
+    assert "Could not create placeholder" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_create_placeholder_files_reraises_unexpected_errors(
+    tmp_path: Path, metadata_cache: MetadataCache
+) -> None:
+    """Only file system errors are absorbed; anything else still surfaces."""
+    settings = Settings()
+    settings.cache_file = tmp_path / "metatadata_cache.json"
+    settings.cache_file.write_text(json.dumps(metadata_cache))
+    recipe_list = ["Recipe1", "Recipe2"]
+
+    with (
+        patch(
+            "cloud_autopkg_runner.autopkg_prefs.AutoPkgPrefs._get_preference_file_contents",
+            return_value={},
+        ),
+        patch(
+            "cloud_autopkg_runner.recipe_finder.RecipeFinder.possible_file_names",
+            return_value=recipe_list,
+        ),
+        patch(
+            "cloud_autopkg_runner.file_utils._create_and_set_attrs",
+            side_effect=ValueError("boom"),
+        ),
+        pytest.raises(ValueError, match="boom"),
+    ):
+        await file_utils.create_placeholder_files(recipe_list)
+
+
+@pytest.mark.asyncio
 async def test_create_placeholder_files_skips_existing(
     tmp_path: Path, metadata_cache: MetadataCache
 ) -> None:
@@ -323,28 +411,29 @@ async def test_get_file_metadata_without_xattr_support(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("errno_to_simulate", "expected_result_is_none"),
+    ("errno_to_simulate", "expect_warning"),
     [
-        # --- Cases where None should be returned ---
+        # An unset attribute is the ordinary case, and stays quiet.
         # ENOATTR on macOS, ENODATA on Linux; both mean "attribute not set"
-        (file_utils._ENOATTR, True),
-        (errno.ENODATA, True),
-        # --- Cases where OSError should be re-raised ---
-        (errno.EIO, False),
-        (errno.ENOTSUP, False),
+        (file_utils._ENOATTR, False),
+        (errno.ENODATA, False),
+        # A read that fails is reported, but never raised at the caller
+        (errno.ENOTSUP, True),
+        (errno.EIO, True),
     ],
 )
 async def test_get_file_metadata_errno_behavior(
     tmp_path: Path,
     mock_xattr: MagicMock,
+    caplog: pytest.LogCaptureFixture,
     errno_to_simulate: int,
-    expected_result_is_none: bool,
+    expect_warning: bool,
 ) -> None:
-    """Test get_file_metadata's errno handling.
+    """A metadata read never raises, whatever the file system reports.
 
-    This test uses parametrization to cover:
-    - Returning None for the 'attribute not found' errors of both platforms.
-    - Re-raising OSErrors for other errno codes.
+    Losing the metadata costs a re-download on the next run. Failing the run
+    over it would cost far more, so every errno reads as "no value", and only
+    the unexpected ones are reported.
     """
     mock_file_path = tmp_path / "testfile.txt"
     mock_attr = file_utils.XATTR_ETAG
@@ -354,19 +443,14 @@ async def test_get_file_metadata_errno_behavior(
         errno_to_simulate, f"Simulated error for errno {errno_to_simulate}"
     )
 
-    if expected_result_is_none:
+    with caplog.at_level(logging.WARNING):
         result = await file_utils.get_file_metadata(mock_file_path, mock_attr)
-        assert result is None, (
-            f"Expected None for errno {errno_to_simulate}, but got {result}"
-        )
-    else:
-        with pytest.raises(OSError) as exc_info:  # noqa: PT011
-            await file_utils.get_file_metadata(mock_file_path, mock_attr)
-        assert exc_info.type is OSError
-        assert exc_info.value.errno == errno_to_simulate, (
-            f"Expected OSError with errno {errno_to_simulate}, "
-            f"but got {exc_info.value.errno}"
-        )
+
+    assert result is None, (
+        f"Expected None for errno {errno_to_simulate}, but got {result}"
+    )
+    warned = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert bool(warned) is expect_warning
 
     # Assert that xattr.getxattr was called as expected in all cases
     mock_xattr.getxattr.assert_called_once_with(mock_file_path, mock_attr)

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -8,7 +8,11 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-import xattr
+
+if sys.platform == "win32":  # xattr publishes no Windows build
+    xattr = None
+else:
+    import xattr
 
 from cloud_autopkg_runner import Settings, file_utils
 from cloud_autopkg_runner.exceptions import InvalidFileSizeError
@@ -77,6 +81,10 @@ def test_set_file_size_rejects_negative(tmp_path: Path) -> None:
         file_utils._set_file_size(file_path, -1)
 
 
+@pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="AutoPkg's xattr namespace is only writable on macOS",
+)
 def test_placeholder_satisfies_urldownloader(tmp_path: Path) -> None:
     """A placeholder must survive the checks AutoPkg's URLDownloader makes.
 
@@ -123,6 +131,19 @@ def test_create_and_set_attrs_with_absent_file_size(
 
     assert file_path.stat().st_size == 0
     mock_xattr.setxattr.assert_not_called()
+
+
+def test_create_and_set_attrs_without_xattr_support(tmp_path: Path) -> None:
+    """Without extended attributes the placeholder is still created at size."""
+    file_path = tmp_path / "placeholder.dmg"
+
+    with patch("cloud_autopkg_runner.file_utils.xattr", new=None):
+        file_utils._create_and_set_attrs(
+            file_path,
+            {"file_path": str(file_path), "file_size": 1024, "etag": "test_etag"},
+        )
+
+    assert file_path.stat().st_size == 1024
 
 
 @pytest.mark.asyncio
@@ -195,6 +216,7 @@ async def test_create_placeholder_files_skips_negative_size(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_xattr")  # AutoPkg's xattr names are macOS-only
 async def test_create_placeholder_files(
     tmp_path: Path, metadata_cache: MetadataCache
 ) -> None:
@@ -274,40 +296,51 @@ async def test_get_file_metadata_invalid_attr(tmp_path: Path) -> None:
     file_path = tmp_path / "test_file.txt"
     file_path.touch()
 
-    result = await file_utils.get_file_metadata(file_path, "non_existant_attr")
+    # Linux only accepts names in a known namespace, so an unprefixed name
+    # would fail with EOPNOTSUPP rather than reporting the attribute as unset.
+    attr = "non_existant_attr" if sys.platform == "darwin" else "user.non_existant_attr"
+
+    result = await file_utils.get_file_metadata(file_path, attr)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_file_metadata_without_xattr_support(tmp_path: Path) -> None:
+    """Without extended attributes, metadata reads report the value as absent."""
+    file_path = tmp_path / "test_file.txt"
+    file_path.touch()
+
+    with patch("cloud_autopkg_runner.file_utils.xattr", new=None):
+        result = await file_utils.get_file_metadata(file_path, "test_attr")
 
     assert result is None
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("platform", "errno_to_simulate", "expected_result_is_none"),
+    ("errno_to_simulate", "expected_result_is_none"),
     [
         # --- Cases where None should be returned ---
-        ("darwin", errno.ENOATTR, True),
-        ("linux", errno.ENODATA, True),
-        ("win32", errno.ENODATA, True),
-        ("darwin", errno.ENODATA, True),
+        # ENOATTR on macOS, ENODATA on Linux; both mean "attribute not set"
+        (file_utils._ENOATTR, True),
+        (errno.ENODATA, True),
         # --- Cases where OSError should be re-raised ---
-        ("linux", errno.ENOATTR, False),
-        ("win32", errno.ENOATTR, False),
-        ("darwin", errno.EIO, False),
-        ("linux", errno.EIO, False),
+        (errno.EIO, False),
+        (errno.ENOTSUP, False),
     ],
 )
 async def test_get_file_metadata_errno_behavior(
     tmp_path: Path,
     mock_xattr: MagicMock,
-    platform: str,
     errno_to_simulate: int,
     expected_result_is_none: bool,
 ) -> None:
-    """Test get_file_metadata's platform-specific errno handling.
+    """Test get_file_metadata's errno handling.
 
     This test uses parametrization to cover:
-    - Returning None for specific 'attribute not found' errors.
+    - Returning None for the 'attribute not found' errors of both platforms.
     - Re-raising OSErrors for other errno codes.
-    - Simulating different platforms using `sys.platform`.
     """
     mock_file_path = tmp_path / "testfile.txt"
     mock_attr = "com.github.autopkg.etag"
@@ -317,25 +350,22 @@ async def test_get_file_metadata_errno_behavior(
         errno_to_simulate, f"Simulated error for errno {errno_to_simulate}"
     )
 
-    with patch.object(sys, "platform", new=platform):
-        if expected_result_is_none:
-            result = await file_utils.get_file_metadata(mock_file_path, mock_attr)
-            assert result is None, (
-                f"Expected None for errno {errno_to_simulate} on {platform}, "
-                f"but got {result}"
-            )
-        else:
-            with pytest.raises(OSError) as exc_info:  # noqa: PT011
-                await file_utils.get_file_metadata(mock_file_path, mock_attr)
-            assert exc_info.type is OSError
-            assert exc_info.value.errno == errno_to_simulate, (
-                f"Expected OSError with errno {errno_to_simulate} on {platform}, "
-                f"but got {exc_info.value.errno}"
-            )
+    if expected_result_is_none:
+        result = await file_utils.get_file_metadata(mock_file_path, mock_attr)
+        assert result is None, (
+            f"Expected None for errno {errno_to_simulate}, but got {result}"
+        )
+    else:
+        with pytest.raises(OSError) as exc_info:  # noqa: PT011
+            await file_utils.get_file_metadata(mock_file_path, mock_attr)
+        assert exc_info.type is OSError
+        assert exc_info.value.errno == errno_to_simulate, (
+            f"Expected OSError with errno {errno_to_simulate}, "
+            f"but got {exc_info.value.errno}"
+        )
 
-        # Assert that xattr.getxattr was called as expected in all cases
-        mock_xattr.getxattr.assert_called_once_with(mock_file_path, mock_attr)
-        mock_xattr.getxattr.reset_mock()  # Reset for the next parameter iteration
+    # Assert that xattr.getxattr was called as expected in all cases
+    mock_xattr.getxattr.assert_called_once_with(mock_file_path, mock_attr)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -82,8 +82,7 @@ def test_set_file_size_rejects_negative(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform != "darwin",
-    reason="AutoPkg's xattr namespace is only writable on macOS",
+    sys.platform == "win32", reason="Windows has no extended attributes"
 )
 def test_placeholder_satisfies_urldownloader(tmp_path: Path) -> None:
     """A placeholder must survive the checks AutoPkg's URLDownloader makes.
@@ -110,13 +109,19 @@ def test_placeholder_satisfies_urldownloader(tmp_path: Path) -> None:
     # produce_etag_headers() reports this as existing_file_size.
     assert file_path.stat().st_size == 219045888
 
+    # The names are spelled out rather than taken from file_utils, since the
+    # point is that they match what URLDownloader.clear_vars() looks up.
+    prefix = "user." if sys.platform.startswith("linux") else ""
+    etag_attr = f"{prefix}com.github.autopkg.etag"
+    last_modified_attr = f"{prefix}com.github.autopkg.last-modified"
+
     # getxattr() looks the name up in listxattr() before reading it.
     listed = xattr.listxattr(file_path)
-    assert "com.github.autopkg.etag" in listed
-    assert "com.github.autopkg.last-modified" in listed
-    assert xattr.getxattr(file_path, "com.github.autopkg.etag").decode() == '"3f8a9c1d"'
+    assert etag_attr in listed
+    assert last_modified_attr in listed
+    assert xattr.getxattr(file_path, etag_attr).decode() == '"3f8a9c1d"'
     assert (
-        xattr.getxattr(file_path, "com.github.autopkg.last-modified").decode()
+        xattr.getxattr(file_path, last_modified_attr).decode()
         == "Wed, 21 Oct 2025 07:28:00 GMT"
     )
 
@@ -216,7 +221,6 @@ async def test_create_placeholder_files_skips_negative_size(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("mock_xattr")  # AutoPkg's xattr names are macOS-only
 async def test_create_placeholder_files(
     tmp_path: Path, metadata_cache: MetadataCache
 ) -> None:
@@ -343,7 +347,7 @@ async def test_get_file_metadata_errno_behavior(
     - Re-raising OSErrors for other errno codes.
     """
     mock_file_path = tmp_path / "testfile.txt"
-    mock_attr = "com.github.autopkg.etag"
+    mock_attr = file_utils.XATTR_ETAG
 
     # Set up the mock to raise the specified OSError
     mock_xattr.getxattr.side_effect = OSError(

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from cloud_autopkg_runner import AutoPkgPrefs, Recipe
+from cloud_autopkg_runner import AutoPkgPrefs, Recipe, file_utils
 from cloud_autopkg_runner.exceptions import (
     InvalidFileContentsError,
     RecipeFormatError,
@@ -418,8 +418,8 @@ async def test_get_metadata_for_item_all_present() -> None:
         mock_get_file_size.return_value = expected_file_size
         # Configure get_file_metadata for specific attributes
         mock_get_file_metadata.side_effect = [
-            expected_etag,  # for "com.github.autopkg.etag"
-            expected_last_modified,  # for "com.github.autopkg.last-modified"
+            expected_etag,  # for the etag attribute
+            expected_last_modified,  # for the last-modified attribute
         ]
 
         result = await Recipe._get_metadata_for_item(test_file_path_str)
@@ -427,11 +427,9 @@ async def test_get_metadata_for_item_all_present() -> None:
         # Assertions for the mock calls
         mock_get_file_size.assert_called_once_with(test_file_path)
         assert mock_get_file_metadata.call_count == 2
+        mock_get_file_metadata.assert_any_call(test_file_path, file_utils.XATTR_ETAG)
         mock_get_file_metadata.assert_any_call(
-            test_file_path, "com.github.autopkg.etag"
-        )
-        mock_get_file_metadata.assert_any_call(
-            test_file_path, "com.github.autopkg.last-modified"
+            test_file_path, file_utils.XATTR_LAST_MODIFIED
         )
 
         # Assertions for the returned DownloadMetadata
@@ -461,19 +459,17 @@ async def test_get_metadata_for_item_missing_optional_metadata() -> None:
         mock_get_file_size.return_value = expected_file_size
         # Simulate missing metadata by returning None
         mock_get_file_metadata.side_effect = [
-            None,  # for "com.github.autopkg.etag"
-            None,  # for "com.github.autopkg.last-modified"
+            None,  # for the etag attribute
+            None,  # for the last-modified attribute
         ]
 
         result = await Recipe._get_metadata_for_item(test_file_path_str)
 
         mock_get_file_size.assert_called_once_with(test_file_path)
         assert mock_get_file_metadata.call_count == 2
+        mock_get_file_metadata.assert_any_call(test_file_path, file_utils.XATTR_ETAG)
         mock_get_file_metadata.assert_any_call(
-            test_file_path, "com.github.autopkg.etag"
-        )
-        mock_get_file_metadata.assert_any_call(
-            test_file_path, "com.github.autopkg.last-modified"
+            test_file_path, file_utils.XATTR_LAST_MODIFIED
         )
 
         # Ensure only file_path and file_size are present
@@ -525,8 +521,8 @@ async def test_get_metadata_for_item_etag_error() -> None:
         mock_get_file_size.return_value = expected_file_size
         # Configure get_file_metadata to raise for etag
         mock_get_file_metadata.side_effect = [
-            expected_error,  # for "com.github.autopkg.etag"
-            "some_last_modified",  # for "com.github.autopkg.last-modified"
+            expected_error,  # for the etag attribute
+            "some_last_modified",  # for the last-modified attribute
         ]
 
         with pytest.raises(OSError) as exc_info:  # noqa: PT011
@@ -535,9 +531,7 @@ async def test_get_metadata_for_item_etag_error() -> None:
         assert exc_info.type is OSError
         assert exc_info.value.errno == expected_error.errno
         mock_get_file_size.assert_called_once_with(test_file_path)
-        mock_get_file_metadata.assert_any_call(
-            test_file_path, "com.github.autopkg.etag"
-        )
+        mock_get_file_metadata.assert_any_call(test_file_path, file_utils.XATTR_ETAG)
 
 
 @pytest.mark.asyncio
@@ -559,8 +553,8 @@ async def test_get_metadata_for_item_last_modified_error() -> None:
     ):
         mock_get_file_size.return_value = expected_file_size
         mock_get_file_metadata.side_effect = [
-            expected_etag,  # for "com.github.autopkg.etag"
-            expected_error,  # for "com.github.autopkg.last-modified"
+            expected_etag,  # for the etag attribute
+            expected_error,  # for the last-modified attribute
         ]
 
         with pytest.raises(OSError) as exc_info:  # noqa: PT011
@@ -569,11 +563,9 @@ async def test_get_metadata_for_item_last_modified_error() -> None:
         assert exc_info.type is OSError
         assert exc_info.value.errno == expected_error.errno
         mock_get_file_size.assert_called_once_with(test_file_path)
+        mock_get_file_metadata.assert_any_call(test_file_path, file_utils.XATTR_ETAG)
         mock_get_file_metadata.assert_any_call(
-            test_file_path, "com.github.autopkg.etag"
-        )
-        mock_get_file_metadata.assert_any_call(
-            test_file_path, "com.github.autopkg.last-modified"
+            test_file_path, file_utils.XATTR_LAST_MODIFIED
         )
 
 

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -1,4 +1,5 @@
 import errno
+import logging
 import plistlib
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -482,11 +483,12 @@ async def test_get_metadata_for_item_missing_optional_metadata() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_metadata_for_item_file_size_error() -> None:
-    """Test _get_metadata_for_item when get_file_size raises an OSError."""
+async def test_get_metadata_for_item_file_size_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unreadable download is left uncached rather than failing the recipe."""
     test_file_path_str = "/tmp/test_downloaded_file.dmg"
     test_file_path = Path(test_file_path_str)
-    # Use EIO for a generic OSError that should cause the function to raise
     expected_error = OSError(errno.EIO, "Input/output error")
 
     with patch(
@@ -494,17 +496,23 @@ async def test_get_metadata_for_item_file_size_error() -> None:
     ) as mock_get_file_size:
         mock_get_file_size.side_effect = expected_error
 
-        with pytest.raises(OSError) as exc_info:  # noqa: PT011
-            await Recipe._get_metadata_for_item(test_file_path_str)
+        with caplog.at_level(logging.WARNING):
+            result = await Recipe._get_metadata_for_item(test_file_path_str)
 
-        assert exc_info.type is OSError
-        assert exc_info.value.errno == expected_error.errno
+        assert result is None
+        assert "Could not read metadata" in caplog.text
         mock_get_file_size.assert_called_once_with(test_file_path)
 
 
 @pytest.mark.asyncio
-async def test_get_metadata_for_item_etag_error() -> None:
-    """Test _get_metadata_for_item when etag retrieval raises an OSError."""
+async def test_get_metadata_for_item_etag_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An etag read that raises leaves the item uncached, not the recipe failed.
+
+    `get_file_metadata` reports an unreadable attribute as absent rather than
+    raising, so this covers the belt-and-braces path.
+    """
     test_file_path_str = "/tmp/test_downloaded_file.dmg"
     test_file_path = Path(test_file_path_str)
     expected_file_size = 12345
@@ -525,18 +533,20 @@ async def test_get_metadata_for_item_etag_error() -> None:
             "some_last_modified",  # for the last-modified attribute
         ]
 
-        with pytest.raises(OSError) as exc_info:  # noqa: PT011
-            await Recipe._get_metadata_for_item(test_file_path_str)
+        with caplog.at_level(logging.WARNING):
+            result = await Recipe._get_metadata_for_item(test_file_path_str)
 
-        assert exc_info.type is OSError
-        assert exc_info.value.errno == expected_error.errno
+        assert result is None
+        assert "Could not read metadata" in caplog.text
         mock_get_file_size.assert_called_once_with(test_file_path)
         mock_get_file_metadata.assert_any_call(test_file_path, file_utils.XATTR_ETAG)
 
 
 @pytest.mark.asyncio
-async def test_get_metadata_for_item_last_modified_error() -> None:
-    """Test _get_metadata_for_item when last_modified retrieval raises an OSError."""
+async def test_get_metadata_for_item_last_modified_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A last-modified read that raises leaves the item uncached."""
     test_file_path_str = "/tmp/test_downloaded_file.dmg"
     test_file_path = Path(test_file_path_str)
     expected_file_size = 12345
@@ -557,11 +567,11 @@ async def test_get_metadata_for_item_last_modified_error() -> None:
             expected_error,  # for the last-modified attribute
         ]
 
-        with pytest.raises(OSError) as exc_info:  # noqa: PT011
-            await Recipe._get_metadata_for_item(test_file_path_str)
+        with caplog.at_level(logging.WARNING):
+            result = await Recipe._get_metadata_for_item(test_file_path_str)
 
-        assert exc_info.type is OSError
-        assert exc_info.value.errno == expected_error.errno
+        assert result is None
+        assert "Could not read metadata" in caplog.text
         mock_get_file_size.assert_called_once_with(test_file_path)
         mock_get_file_metadata.assert_any_call(test_file_path, file_utils.XATTR_ETAG)
         mock_get_file_metadata.assert_any_call(

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -7,14 +7,44 @@ import pytest
 from cloud_autopkg_runner import shell
 from cloud_autopkg_runner.exceptions import ShellCommandError
 
-# Portable long-running command; `sleep` is unavailable on Windows.
+# The unit suite runs on macOS, Linux and Windows, so every command here is
+# spelled as a Python invocation. Shell builtins and coreutils (`echo`,
+# `false`, `cat`, `sleep`) do not exist as executables on Windows, and
+# `create_subprocess_exec` never goes through a shell.
+PYTHON = Path(sys.executable).as_posix()
+
+ECHO_CMD = [sys.executable, "-c", 'print("Hello, world!")']
+FAIL_CMD = [sys.executable, "-c", "raise SystemExit(1)"]
 SLEEP_CMD = [sys.executable, "-c", "import time; time.sleep(30)"]
+READ_FILE_CMD = [
+    sys.executable,
+    "-c",
+    "import pathlib, sys; sys.stdout.write(pathlib.Path(sys.argv[1]).read_text())",
+]
+
+
+def python_cmd_str(code: str) -> str:
+    """Build a `python -c` command as a string that `shlex.split` can parse.
+
+    The interpreter path is quoted (it may contain spaces) and rendered with
+    forward slashes, since `shlex.split` strips Windows path separators as
+    escape characters. `code` must not contain single quotes.
+
+    Args:
+        code: The Python source to pass to `-c`.
+
+    Returns:
+        A command string suitable for `shell.run_cmd`.
+    """
+    return f"\"{PYTHON}\" -c '{code}'"
 
 
 @pytest.mark.asyncio
 async def test_run_cmd_success() -> None:
     """Test successful command execution."""
-    returncode, stdout, stderr = await shell.run_cmd("echo 'Hello, world!'")
+    returncode, stdout, stderr = await shell.run_cmd(
+        python_cmd_str('print("Hello, world!")')
+    )
     assert returncode == 0
     assert "Hello, world!" in stdout
     assert not stderr
@@ -24,25 +54,25 @@ async def test_run_cmd_success() -> None:
 async def test_run_cmd_failure() -> None:
     """Test command execution with a non-zero exit code."""
     with pytest.raises(ShellCommandError) as exc_info:
-        await shell.run_cmd("false")
-    assert "Command failed with exit code 1: false" in str(exc_info.value)
+        await shell.run_cmd(FAIL_CMD)
+    assert f"Command failed with exit code 1: {' '.join(FAIL_CMD)}" in str(
+        exc_info.value
+    )
 
 
 @pytest.mark.asyncio
 async def test_run_cmd_no_check() -> None:
     """Test command execution with check=False."""
-    returncode, stdout, stderr = await shell.run_cmd("false", check=False)
+    returncode, stdout, stderr = await shell.run_cmd(FAIL_CMD, check=False)
     assert returncode == 1
     assert not stdout
-    assert not stderr
+    assert not stderr  # SystemExit with an integer code prints nothing
 
 
 @pytest.mark.asyncio
 async def test_run_cmd_capture_output_false() -> None:
     """Test command execution with capture_output=False."""
-    returncode, stdout, stderr = await shell.run_cmd(
-        "echo 'Hello, world!'", capture_output=False
-    )
+    returncode, stdout, stderr = await shell.run_cmd(ECHO_CMD, capture_output=False)
     assert returncode == 0
     assert not stdout
     assert not stderr
@@ -55,9 +85,9 @@ async def test_run_cmd_cwd(tmp_path: Path) -> None:
     test_file = tmp_path / "test.txt"
     test_file.write_text("Test content")
 
-    # Run a command that reads the file in the temporary directory
+    # Read the file by its relative name, so it is only found via cwd
     returncode, stdout, stderr = await shell.run_cmd(
-        f"cat {test_file}", cwd=str(tmp_path)
+        [*READ_FILE_CMD, test_file.name], cwd=str(tmp_path)
     )
     assert returncode == 0
     assert "Test content" in stdout
@@ -68,8 +98,10 @@ async def test_run_cmd_cwd(tmp_path: Path) -> None:
 async def test_run_cmd_timeout() -> None:
     """Test command execution with a timeout."""
     with pytest.raises(ShellCommandError) as exc_info:
-        await shell.run_cmd("sleep 2", timeout=1)
-    assert "Command failed with exit code -1: sleep 2" in str(exc_info.value)
+        await shell.run_cmd(SLEEP_CMD, timeout=1)
+    assert f"Command failed with exit code -1: {' '.join(SLEEP_CMD)}" in str(
+        exc_info.value
+    )
 
 
 @pytest.mark.asyncio
@@ -85,7 +117,7 @@ async def test_run_cmd_shell_injection_safe() -> None:
     """Test that shell.run_cmd is safe from shell injection."""
     # Attempt to inject a command using a semicolon
     returncode, stdout, stderr = await shell.run_cmd(
-        "echo 'hello; rm -rf /'", check=False
+        python_cmd_str('print("hello; rm -rf /")'), check=False
     )  # Removed injection
     assert returncode == 0
     assert "hello; rm -rf /" in stdout  # Injection is treated as literal
@@ -102,7 +134,7 @@ async def test_run_cmd_shell_injection_safe() -> None:
 @pytest.mark.asyncio
 async def test_run_cmd_list_command() -> None:
     """Test command execution with a list command."""
-    returncode, stdout, stderr = await shell.run_cmd(["echo", "Hello, world!"])
+    returncode, stdout, stderr = await shell.run_cmd(ECHO_CMD)
     assert returncode == 0
     assert "Hello, world!" in stdout
     assert not stderr
@@ -114,12 +146,11 @@ async def test_run_cmd_file_not_found_error(tmp_path: Path) -> None:
     # Create a temporary directory
     cwd = str(tmp_path)
 
-    # Test running 'cat non_existent_file.txt' command in the directory
+    # Read a file that does not exist in the directory
+    cmd = [*READ_FILE_CMD, "non_existent_file.txt"]
     with pytest.raises(ShellCommandError) as exc_info:
-        await shell.run_cmd("cat non_existent_file.txt", cwd=cwd)
-    assert "Command failed with exit code 1: cat non_existent_file.txt" in str(
-        exc_info.value
-    )
+        await shell.run_cmd(cmd, cwd=cwd)
+    assert f"Command failed with exit code 1: {' '.join(cmd)}" in str(exc_info.value)
 
 
 class ProcessTracker:
@@ -182,10 +213,11 @@ async def test_run_cmd_reaps_subprocess_on_timeout() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_cmd_os_error() -> None:
+async def test_run_cmd_os_error(tmp_path: Path) -> None:
     """Test OSError when the command encounters an OS-level error."""
-    # Use an invalid command that will cause an OSError
+    # A directory exists but cannot be executed, so this fails with a
+    # PermissionError rather than a FileNotFoundError on every platform.
     with pytest.raises(ShellCommandError) as exc_info:
-        await shell.run_cmd("/dev/null")
+        await shell.run_cmd([str(tmp_path)])
     # Check if the error message contains "Permission denied" or "Not executable"
     assert "OS error" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -512,7 +512,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "xattr" },
+    { name = "xattr", marker = "sys_platform != 'win32'" },
 ]
 
 [package.optional-dependencies]
@@ -548,7 +548,7 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'gcs'" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.3.0" },
-    { name = "xattr", specifier = ">=1.1.4" },
+    { name = "xattr", marker = "sys_platform != 'win32'", specifier = ">=1.1.4" },
 ]
 provides-extras = ["azure", "gcs", "json", "s3", "sqlite"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -530,7 +530,7 @@ s3 = [
 [package.dev-dependencies]
 dev = [
     { name = "hypothesis" },
-    { name = "localstack" },
+    { name = "localstack", marker = "sys_platform != 'win32'" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest-asyncio" },
@@ -538,6 +538,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-boto3-lite", extra = ["s3"] },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -555,7 +556,7 @@ provides-extras = ["azure", "gcs", "json", "s3", "sqlite"]
 [package.metadata.requires-dev]
 dev = [
     { name = "hypothesis", specifier = ">=6.138.8" },
-    { name = "localstack", specifier = ">=4.7.0" },
+    { name = "localstack", marker = "sys_platform != 'win32'", specifier = ">=4.7.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pyright", specifier = ">=1.1.397" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
@@ -563,6 +564,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.12.7" },
     { name = "types-boto3-lite", extras = ["s3"], specifier = ">=1.40.70" },
+    { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2025.1" },
 ]
 
 [[package]]
@@ -781,7 +783,6 @@ name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "urllib3" },
 ]
@@ -1202,7 +1203,6 @@ dependencies = [
     { name = "rich" },
     { name = "semver" },
     { name = "tabulate" },
-    { name = "windows-curses", marker = "sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/ba/112723e506c2d8c8fd5c5b13e6a98e18820a05c1aec61270bf3032f2a2a8/localstack-2026.7.0-py3-none-any.whl", hash = "sha256:eae6a8c17c870a637b5e6404774569a5d9d317f423c1bfe78394568951d7e814", size = 177088, upload-time = "2026-07-22T08:18:25.758Z" },
@@ -1605,22 +1605,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
     { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
     { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
     { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
     { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
     { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
     { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
     { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
     { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
     { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
     { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
     { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1779,28 +1773,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "pywin32"
-version = "311"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
-    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
-    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
-    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -2093,6 +2065,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2114,21 +2095,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
-]
-
-[[package]]
-name = "windows-curses"
-version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/34/e70815e7ae6f157c00121180a607dbcdc82acfd949c70bba28c45d206dec/windows_curses-2.4.1-cp310-cp310-win32.whl", hash = "sha256:53d711e07194d0d3ff7ceff29e0955b35479bc01465d46c3041de67b8141db2f", size = 71136, upload-time = "2025-01-11T00:26:15.273Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/1d/1bb512c445af24fb0a3dccf9537c8727bba5920e69539227b87f5351f608/windows_curses-2.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:325439cd4f37897a1de8a9c068a5b4c432f9244bf9c855ee2fbeb3fa721a770c", size = 81418, upload-time = "2025-01-11T00:26:16.963Z" },
-    { url = "https://files.pythonhosted.org/packages/74/b3/46a2508fff83b5affb5a311797c584c494b4b0c4c8796a1afa2c1b1e03ac/windows_curses-2.4.1-cp311-cp311-win32.whl", hash = "sha256:4fa1a176bfcf098d0c9bb7bc03dce6e83a4257fc0c66ad721f5745ebf0c00746", size = 71129, upload-time = "2025-01-11T00:26:19.137Z" },
-    { url = "https://files.pythonhosted.org/packages/50/29/fd7c0c80177d8df55f841504a5f332b95b0002c80f82055913b6caac94e6/windows_curses-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:fd7d7a9cf6c1758f46ed76b8c67f608bc5fcd5f0ca91f1580fd2d84cf41c7f4f", size = 81431, upload-time = "2025-01-11T00:26:20.359Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/99/60f34e51514c82631aa5c6d21eab88ce1701562de9844608411e39462a46/windows_curses-2.4.1-cp312-cp312-win32.whl", hash = "sha256:bdbe7d58747408aef8a9128b2654acf6fbd11c821b91224b9a046faba8c6b6ca", size = 71489, upload-time = "2025-01-11T00:26:22.726Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8f/d908bcab1954375b156a9300fa86ceccb110f39457cd6fd59c72777626ab/windows_curses-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c9c2635faf171a229caca80e1dd760ab00db078e2a285ba2f667bbfcc31777c", size = 81777, upload-time = "2025-01-11T00:26:25.273Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a0/e8d074f013117633f6b502ca123ecfc377fe0bd36818fe65e8935c91ca9c/windows_curses-2.4.1-cp313-cp313-win32.whl", hash = "sha256:05d1ca01e5199a435ccb6c8c2978df4a169cdff1ec99ab15f11ded9de8e5be26", size = 71390, upload-time = "2025-01-11T00:26:27.66Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/4b/2838a829b074a68c570d54ae0ae8539979657d3e619a4dc5a4b03eb69745/windows_curses-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8cf653f8928af19c103ae11cfed38124f418dcdd92643c4cd17239c0cec2f9da", size = 81636, upload-time = "2025-01-11T00:26:29.595Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
:black_heart:

Fixes #231
Fixes #227

Two issues that turned out to be the same story: we claimed Linux and Windows coverage we did not have, and the thing that coverage would have caught was a metadata cache that does nothing on Linux.

## #231 — the matrix ran everything on macOS

The `os` matrix was only interpolated into the job name, so all fifteen unit test combinations ran on macOS. `runs-on` now points at `matrix.os`, and `fail-fast: false` keeps one platform's failure from cancelling the other jobs.

Honoring the matrix means the jobs have to actually pass, which took a few prerequisites:

- **`xattr` has no Windows build.** Importing it unconditionally made the package unimportable there, and `uv sync` would have failed before a single test ran. The dependency is now marked `sys_platform != 'win32'`, `file_utils` imports it conditionally, and the two call sites log a WARNING and skip the etag and last-modified attributes when it is absent. Placeholders are still created at their cached size.
- **`errno.ENOATTR` is only defined on BSD-derived platforms.** The runtime check short-circuited safely behind `sys.platform == "darwin"`, but the test parametrized it at collection time, which would raise `AttributeError` on Linux and Windows. Both errnos now live in one `_MISSING_ATTR_ERRNOS` set, so the platform branch is gone and macOS behavior is unchanged.
- **The shell tests shelled out to `echo`, `false`, `cat`, `sleep` and `/dev/null`**, none of which are executables on Windows, and interpolated paths into command strings that `shlex.split` strips backslashes from. Every command is now a `python -c` invocation, in list form wherever a path is involved.
- **Dev dependencies Windows cannot install.** `localstack` drives the integration suite, which only runs on Linux, and it pulls in `windows-curses`, which has no wheel for Python 3.14 on Windows. Hypothesis generates aware datetimes, which need a time zone database Windows does not ship. Both are now scoped by marker.
- One assertion compared a serialized path against a POSIX string literal.

## #227 — the cache was inert on Linux

AutoPkg's `URLDownloader.clear_vars()` prefixes its extended attribute names with `user.` on Linux, whose kernel only accepts attributes in a known namespace. We hardcoded the unprefixed names on both sides, so the write failed outright and the read found nothing — placeholders carried no etag, `URLDownloader` sent no `If-None-Match`, and every download ran in full.

Both names are now derived in one place from the running platform, the way AutoPkg does it, and used for the write in `file_utils` and the read in `recipe`.

## An OSError in the metadata path failed recipes that had succeeded

Found while reviewing the above, and fixed here because the platform work is what surfaced it.

A file system that rejects extended attributes reports `ENOTSUP`, which is not one of the "attribute not set" errnos, so it propagated. Every step of the metadata path could raise: reading an attribute, writing one, creating the placeholder at all (the tasks were gathered without `return_exceptions`, so one read-only volume took down every recipe), and the `get_file_size` call in `_get_metadata_for_item`.

Any of those escaped `Recipe.run()` into `_recipe_worker`'s `except Exception`, which logs a traceback at ERROR and records the recipe as **failed** — after `autopkg` had already run and downloaded successfully.

The metadata cache is an optimization, so each step now degrades to a WARNING: a read reports the value as absent, a write leaves the placeholder without its attributes, a placeholder that cannot be written is skipped while the others stand, and an item whose file cannot be read is left out of the cache. Each costs a download on the next run rather than a failed recipe. Anything that is not an `OSError` still propagates untouched, so a cancelled run still cancels.

## Testing

- macOS: 420 unit tests pass, coverage 91%, `ruff`, `ruff format` and `pyright` clean (pyright also checked under `--pythonplatform` Darwin, Linux and Windows).
- Linux, in a container with `tmp_path` on ext4: 417 pass as of the xattr-naming commit. Confirmed directly that `setxattr` of an unprefixed `com.github.autopkg.etag` fails with `ENOTSUP` on both overlayfs and ext4, and that the `user.`-prefixed name succeeds — which is what makes `test_placeholder_satisfies_urldownloader` run on Linux now instead of being skipped. That test asserts the literal names per platform rather than reading them back from `file_utils`, so a wrong prefix fails it.
- Windows: covered by this PR's own CI, which is the point of #231. All fifteen unit jobs are green.

## Note

`_create_and_set_attrs` no longer fails on Linux, but AutoPkg itself is still macOS-only here (`/usr/local/bin/autopkg` is hardcoded and the classifiers say macOS). The Linux and Windows jobs prove the library imports and its unit tests pass there; they do not claim the tool runs there.
