### PR TITLE
Make the path to AutoPkg configurable

### DIFF
--- a/src/cloud_autopkg_runner/__main__.py
+++ b/src/cloud_autopkg_runner/__main__.py
@@ -81,6 +81,7 @@ def _schema_overrides_from_cli(args: Namespace) -> dict[str, object]:
     overrides: dict[str, object] = {}
 
     for key in (
+        "autopkg_path",
         "autopkg_pref_file",
         "azure_account_url",
         "cache_file",
@@ -386,6 +387,11 @@ def _parse_arguments() -> Namespace:
 
     # AutoPkg
     autopkg = parser.add_argument_group("AutoPkg Preferences")
+    autopkg.add_argument(
+        "--autopkg-path",
+        help="Path to the AutoPkg executable. Defaults to /usr/local/bin/autopkg.",
+        type=Path,
+    )
     autopkg.add_argument(
         "--autopkg-pref-file",
         help="Path to the AutoPkg preferences file.",

--- a/src/cloud_autopkg_runner/config_schema.py
+++ b/src/cloud_autopkg_runner/config_schema.py
@@ -48,6 +48,7 @@ class ConfigSchema:
     post_processors: list[str] | None = None
 
     # AutoPkg
+    autopkg_path: Path | None = None
     autopkg_pref_file: Path | None = None
 
     @classmethod

--- a/src/cloud_autopkg_runner/recipe.py
+++ b/src/cloud_autopkg_runner/recipe.py
@@ -317,7 +317,7 @@ class Recipe:
         prefs_file_path: Path = await self._autopkg_prefs.to_json_file(indent=2)
 
         cmd: list[str] = [
-            "/usr/local/bin/autopkg",
+            str(self._settings.autopkg_path),
             "run",
             self.name,
             "--quiet",
@@ -754,7 +754,7 @@ class Recipe:
         prefs_file_path: Path = await self._autopkg_prefs.to_json_file(indent=2)
 
         cmd: list[str] = [
-            "/usr/local/bin/autopkg",
+            str(self._settings.autopkg_path),
             "update-trust-info",
             self.name,
             f"--override-dir={self._path.parent}",
@@ -793,7 +793,7 @@ class Recipe:
             prefs_file_path: Path = await self._autopkg_prefs.to_json_file(indent=2)
 
             cmd: list[str] = [
-                "/usr/local/bin/autopkg",
+                str(self._settings.autopkg_path),
                 "verify-trust-info",
                 self.name,
                 f"--override-dir={self._path.parent}",

--- a/src/cloud_autopkg_runner/settings.py
+++ b/src/cloud_autopkg_runner/settings.py
@@ -60,6 +60,7 @@ class Settings:
         if hasattr(self, "_initialized"):
             return  # Prevent re-initialization
 
+        self._autopkg_path: Path = Path("/usr/local/bin/autopkg")
         self._autopkg_pref_file: Path = Path(
             "~/Library/Preferences/com.github.autopkg.plist"
         ).expanduser()
@@ -91,6 +92,27 @@ class Settings:
             schema_value = getattr(schema, field.name)
             if schema_value is not None:
                 setattr(self, field.name, schema_value)
+
+    @property
+    def autopkg_path(self) -> Path:
+        """Get the path to the AutoPkg executable.
+
+        Returns:
+            The path to the AutoPkg executable.
+        """
+        return self._autopkg_path
+
+    @autopkg_path.setter
+    def autopkg_path(self, value: str | Path) -> None:
+        """Set the path to the AutoPkg executable.
+
+        Args:
+            value: The new path to the AutoPkg executable. Can be either a
+                string or a Path object. Homebrew on Apple silicon installs it
+                under `/opt/homebrew/bin`, and a virtualenv or a bundled copy
+                will be somewhere else again.
+        """
+        self._autopkg_path = self._convert_to_path(value).expanduser()
 
     @property
     def autopkg_pref_file(self) -> Path:

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -70,6 +70,7 @@ def test_cli_overrides_schema(tmp_path: Path) -> None:
         post_processor=["com.example.identifier/postProcessorName"],
         azure_account_url=None,
         cloud_container_name=None,
+        autopkg_path=Path("/opt/homebrew/bin/autopkg"),
         autopkg_pref_file=None,
         key=[("KEY1", "VALUE1"), ("KEY2", "VALUE2")],
     )
@@ -91,6 +92,7 @@ def test_cli_overrides_schema(tmp_path: Path) -> None:
     assert settings.pre_processors == ["com.example.identifier/preProcessorName"]
     assert settings.post_processors == ["com.example.identifier/postProcessorName"]
     assert settings.input_variables == {"KEY1": "VALUE1", "KEY2": "VALUE2"}
+    assert settings.autopkg_path == Path("/opt/homebrew/bin/autopkg")
 
 
 def test_generate_recipe_list_from_schema() -> None:
@@ -607,6 +609,7 @@ def _cli_namespace() -> Namespace:
         A Namespace matching the attributes _async_main reads.
     """
     return Namespace(
+        autopkg_path=None,
         autopkg_pref_file=None,
         azure_account_url=None,
         cache_file=None,

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -220,6 +220,7 @@ async def test_autopkg_run_cmd_basic(
     report_dir.mkdir()
 
     with patch("cloud_autopkg_runner.recipe.Settings") as mock_settings:
+        mock_settings.return_value.autopkg_path = Path("/usr/local/bin/autopkg")
         mock_settings.return_value.pre_processors = []
         mock_settings.return_value.post_processors = []
         mock_settings.return_value.verbosity_int.return_value = 0
@@ -252,6 +253,7 @@ async def test_autopkg_run_cmd_with_check(
     report_dir.mkdir()
 
     with patch("cloud_autopkg_runner.recipe.Settings") as mock_settings:
+        mock_settings.return_value.autopkg_path = Path("/usr/local/bin/autopkg")
         mock_settings.return_value.pre_processors = []
         mock_settings.return_value.post_processors = []
         mock_settings.return_value.verbosity_int.return_value = 0
@@ -261,6 +263,49 @@ async def test_autopkg_run_cmd_with_check(
         cmd = await recipe._autopkg_run_cmd(check=True)
 
         assert "--check" in cmd
+
+
+@pytest.mark.asyncio
+async def test_autopkg_run_cmd_honors_configured_autopkg_path(
+    tmp_path: Path, mock_autopkg_prefs: MagicMock
+) -> None:
+    """AutoPkg is invoked wherever it is installed, not at a fixed path."""
+    yaml_content = """
+    Description: Test
+    Identifier: com.example.test
+    Input:
+        NAME: TestRecipe
+    Process: []
+    """
+    recipe_file = tmp_path / "test.recipe.yaml"
+    create_test_file(recipe_file, yaml_content)
+    report_dir = tmp_path / "report"
+    report_dir.mkdir()
+
+    # Where Homebrew puts it on Apple silicon
+    autopkg_path = Path("/opt/homebrew/bin/autopkg")
+
+    with patch("cloud_autopkg_runner.recipe.Settings") as mock_settings:
+        mock_settings.return_value.autopkg_path = autopkg_path
+        mock_settings.return_value.pre_processors = []
+        mock_settings.return_value.post_processors = []
+        mock_settings.return_value.verbosity_int.return_value = 0
+        mock_settings.return_value.verbosity_str.return_value = ""
+
+        recipe = Recipe(recipe_file, report_dir, mock_autopkg_prefs)
+
+        assert (await recipe._autopkg_run_cmd())[0] == str(autopkg_path)
+
+        with patch(
+            "cloud_autopkg_runner.recipe.shell.run_cmd", new_callable=AsyncMock
+        ) as mock_run_cmd:
+            mock_run_cmd.return_value = (0, "", "")
+
+            await recipe.update_trust_info()
+            assert mock_run_cmd.call_args.args[0][0] == str(autopkg_path)
+
+            await recipe.verify_trust_info()
+            assert mock_run_cmd.call_args.args[0][0] == str(autopkg_path)
 
 
 @pytest.mark.asyncio
@@ -281,6 +326,7 @@ async def test_autopkg_run_cmd_with_processors_and_verbosity(
     report_dir.mkdir()
 
     with patch("cloud_autopkg_runner.recipe.Settings") as mock_settings:
+        mock_settings.return_value.autopkg_path = Path("/usr/local/bin/autopkg")
         mock_settings.return_value.pre_processors = [
             "PreA",
             "com.example.test/PreProcessorB",
@@ -319,6 +365,7 @@ async def test_autopkg_run_cmd_with_input_variables(
     report_dir.mkdir()
 
     with patch("cloud_autopkg_runner.recipe.Settings") as mock_settings:
+        mock_settings.return_value.autopkg_path = Path("/usr/local/bin/autopkg")
         mock_settings.return_value.pre_processors = []
         mock_settings.return_value.post_processors = []
         mock_settings.return_value.input_variables = {

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -219,8 +219,10 @@ async def test_autopkg_run_cmd_basic(
     report_dir = tmp_path / "report"
     report_dir.mkdir()
 
+    autopkg_path = Path("/usr/local/bin/autopkg")
+
     with patch("cloud_autopkg_runner.recipe.Settings") as mock_settings:
-        mock_settings.return_value.autopkg_path = Path("/usr/local/bin/autopkg")
+        mock_settings.return_value.autopkg_path = autopkg_path
         mock_settings.return_value.pre_processors = []
         mock_settings.return_value.post_processors = []
         mock_settings.return_value.verbosity_int.return_value = 0
@@ -229,7 +231,8 @@ async def test_autopkg_run_cmd_basic(
         recipe = Recipe(recipe_file, report_dir, mock_autopkg_prefs)
         cmd = await recipe._autopkg_run_cmd()
 
-        assert cmd[:3] == ["/usr/local/bin/autopkg", "run", recipe.name]
+        # str(Path) so the separator matches whatever platform this runs on
+        assert cmd[:3] == [str(autopkg_path), "run", recipe.name]
         assert any(arg.startswith("--report-plist=") for arg in cmd)
         assert "--check" not in cmd
         assert not any(arg.startswith("--key=") for arg in cmd)

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -26,6 +26,27 @@ def test_attribute_access() -> None:
     assert isinstance(settings.report_dir, Path)
     assert isinstance(settings.verbosity_level, int)
     assert isinstance(settings.input_variables, dict)
+    assert isinstance(settings.autopkg_path, Path)
+
+
+def test_autopkg_path_default() -> None:
+    """AutoPkg's usual location stays the default."""
+    settings = Settings()
+    assert settings.autopkg_path == Path("/usr/local/bin/autopkg")
+
+
+def test_autopkg_path_setter() -> None:
+    """Test setting autopkg_path from a string or a Path, including a `~`."""
+    settings = Settings()
+
+    settings.autopkg_path = Path("/opt/homebrew/bin/autopkg")
+    assert settings.autopkg_path == Path("/opt/homebrew/bin/autopkg")
+
+    settings.autopkg_path = "/opt/homebrew/bin/autopkg"
+    assert settings.autopkg_path == Path("/opt/homebrew/bin/autopkg")
+
+    settings.autopkg_path = "~/.venv/bin/autopkg"
+    assert settings.autopkg_path == Path("~/.venv/bin/autopkg").expanduser()
 
 
 def test_cache_file_setter() -> None:


### PR DESCRIPTION
:black_heart:

Fixes #234

`Recipe` invoked `/usr/local/bin/autopkg` by absolute path in `_autopkg_run_cmd`, `update_trust_info` and `verify_trust_info`, so any other installation failed at the first recipe with `Command not found`. Homebrew on Apple silicon installs under `/opt/homebrew`, and a virtualenv or a bundled copy is somewhere else again.

## The setting

`autopkg_path` follows the path the architecture already lays out for a config option: a `ConfigSchema` field, the argparse block in `_parse_arguments`, the key tuple in `_schema_overrides_from_cli`, and a `Settings` property whose setter runs `_convert_to_path(...).expanduser()` like its siblings. All three call sites read it.

**It defaults to the path that was hardcoded**, so an existing install sees no change.

```toml
# config.toml
[cloud_autopkg_runner]
autopkg_path = "/opt/homebrew/bin/autopkg"
```

```bash
cloud-autopkg-runner --autopkg-path /opt/homebrew/bin/autopkg --recipe Firefox.download.recipe
```

```python
Settings().autopkg_path = Path("/opt/homebrew/bin/autopkg")
```

## Testing

423 unit tests pass, coverage 92%, `ruff`, `ruff format` and `pyright` clean.

A new test asserts all three AutoPkg subcommands invoke the configured path — as the issue anticipated, that is checkable now without patching the shell layer.

Unit tests alone would not prove the config key is actually accepted end to end, so that was exercised directly:

```
loaded from TOML: {'autopkg_path': '/opt/homebrew/bin/autopkg'}
default before load: /usr/local/bin/autopkg
after config file:   /opt/homebrew/bin/autopkg
after CLI override:  /Users/…/venv/bin/autopkg
```

`--help` lists the flag, `~` expands, and a CLI value beats the config file.

## Docs

The wiki needs a matching change — a row in `Command-Line-Arguments.md` and the key plus a `settings.autopkg_path` example in `Configuration.md`. It lives in its own repo, so it is not part of this PR.
