### PR TITLE
Require a Collection of recipes, not a one-shot iterable

### DIFF
--- a/src/cloud_autopkg_runner/__main__.py
+++ b/src/cloud_autopkg_runner/__main__.py
@@ -394,8 +394,7 @@ async def _process_recipe_list(
     issues during recipe object creation and allows for cleaner timeout handling.
 
     Args:
-        recipe_list: A collection of recipe names. It is both counted and
-            iterated, so a one-shot iterator is not accepted.
+        recipe_list: A collection of recipe names.
         autopkg_prefs: AutoPkg preferences.
 
     Returns:

--- a/src/cloud_autopkg_runner/__main__.py
+++ b/src/cloud_autopkg_runner/__main__.py
@@ -26,11 +26,11 @@ import os
 import signal
 import sys
 from argparse import ArgumentParser, ArgumentTypeError, Namespace
-from collections.abc import Iterable
+from collections.abc import Collection
 from importlib.metadata import metadata
 from pathlib import Path
 from types import FrameType
-from typing import NoReturn, TypeVar
+from typing import NoReturn
 
 from cloud_autopkg_runner import (
     AutoPkgPrefs,
@@ -51,8 +51,6 @@ from cloud_autopkg_runner.logging_context import recipe_context
 from cloud_autopkg_runner.recipe_report import RunResults
 
 logger = logging_config.get_logger(__name__)
-
-T = TypeVar("T")
 
 # Constant that indicates a worker queue is empty and can be stopped
 STOP_WORKER = "<<STOP_WORKER>>"
@@ -107,21 +105,6 @@ def _schema_overrides_from_cli(args: Namespace) -> dict[str, object]:
         overrides["input_variables"] = dict(args.key)
 
     return overrides
-
-
-def _count_iterable(iterable: Iterable[T]) -> int:
-    """Count the number of elements in an iterable.
-
-    This function consumes the entire iterable to determine its length,
-    which means it should not be used on infinite iterators.
-
-    Args:
-        iterable: An iterable collection of elements of type T.
-
-    Returns:
-        The number of elements in the iterable.
-    """
-    return sum(1 for _element in iterable)
 
 
 async def _create_recipe(
@@ -402,7 +385,7 @@ def _parse_arguments() -> Namespace:
 
 
 async def _process_recipe_list(
-    recipe_list: Iterable[str], autopkg_prefs: AutoPkgPrefs
+    recipe_list: Collection[str], autopkg_prefs: AutoPkgPrefs
 ) -> RunResults:
     """Create and run AutoPkg recipes using a worker queue pattern.
 
@@ -411,7 +394,8 @@ async def _process_recipe_list(
     issues during recipe object creation and allows for cleaner timeout handling.
 
     Args:
-        recipe_list: An iterable of recipe names.
+        recipe_list: A collection of recipe names. It is both counted and
+            iterated, so a one-shot iterator is not accepted.
         autopkg_prefs: AutoPkg preferences.
 
     Returns:
@@ -419,7 +403,7 @@ async def _process_recipe_list(
     """
     settings = Settings()
 
-    num_workers = min(settings.max_concurrency, _count_iterable(recipe_list))
+    num_workers = min(settings.max_concurrency, len(recipe_list))
 
     # Populate the Queue
     queue: asyncio.Queue[str] = asyncio.Queue()

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -18,7 +18,6 @@ from cloud_autopkg_runner.__main__ import (
     EXIT_SUCCESS,
     STOP_WORKER,
     _async_main,
-    _count_iterable,
     _create_recipe,
     _generate_recipe_list,
     _get_recipe_path,
@@ -37,9 +36,6 @@ from cloud_autopkg_runner.exceptions import (
     RecipeLookupError,
 )
 from cloud_autopkg_runner.recipe_report import ConsolidatedReport, RunResults
-
-if typing.TYPE_CHECKING:
-    from collections.abc import Iterable
 
 
 @pytest.fixture
@@ -343,24 +339,6 @@ async def test_get_recipe_path_recipe_lookup_error(
         pytest.raises(RecipeLookupError),
     ):
         await _get_recipe_path("test_recipe", mock_autopkg_prefs)
-
-
-def test_count_iterable_str() -> None:
-    """Test that _count_iterable returns the correct value."""
-    mock_iterable: Iterable[str] = iter(["foo", "bar", "baz"])
-    result = _count_iterable(mock_iterable)
-
-    assert result == 3
-    assert type(result) is int
-
-
-def test_count_iterable_int() -> None:
-    """Test that _count_iterable returns the correct value."""
-    mock_iterable: Iterable[int] = iter([1, 2, 3])
-    result = _count_iterable(mock_iterable)
-
-    assert result == 3
-    assert type(result) is int
 
 
 def test_key_value_pair() -> None:


### PR DESCRIPTION
:black_heart:

Fixes #232.

`_process_recipe_list` counted its argument with `_count_iterable` before filling the work queue. Counting consumes an iterator, so a generator argument would have left the queue empty — the run would have processed no recipes and exited successfully having done no work. Every caller passes a `set` today, so nothing was broken in practice; the signature was just dishonest about what it accepts.

The parameter is now `Collection[str]` and the count is `len()`. `_count_iterable` had no other callers, so it and its now-unused `TypeVar` are removed along with its two tests.

Not a breaking change: both symbols are private to `__main__.py` and neither is exported from the package.

`ruff check`, `ruff format --check`, `pyright`, and the 421 unit tests all pass.