### PR TITLE
Derive CLI overrides from the schema, and name unconfigured cloud settings

### DIFF
--- a/src/cloud_autopkg_runner/__main__.py
+++ b/src/cloud_autopkg_runner/__main__.py
@@ -21,6 +21,7 @@ The application workflow typically includes the following steps:
 """
 
 import asyncio
+import dataclasses
 import json
 import os
 import signal
@@ -70,39 +71,28 @@ def _schema_overrides_from_cli(args: Namespace) -> dict[str, object]:
     suitable for applying as overrides to ConfigSchema. Only arguments
     explicitly provided by the user are included.
 
+    Arguments are matched to schema fields by name, so an argument reaches
+    the schema as long as its `dest` matches a `ConfigSchema` field.
+    Arguments with no matching field, such as `--config-file` and
+    `--recipe`, are consumed elsewhere and ignored here.
+
     Args:
         args: Parsed command-line arguments.
 
     Returns:
         A dictionary of schema field overrides.
     """
-    overrides: dict[str, object] = {}
+    schema_fields = {field.name for field in dataclasses.fields(ConfigSchema)}
 
-    for key in (
-        "autopkg_path",
-        "autopkg_pref_file",
-        "azure_account_url",
-        "cache_file",
-        "cache_plugin",
-        "cloud_container_name",
-        "log_file",
-        "log_format",
-        "max_concurrency",
-        "recipe_timeout",
-        "report_dir",
-    ):
-        if hasattr(args, key) and getattr(args, key) is not None:
-            overrides[key] = getattr(args, key)
+    overrides: dict[str, object] = {
+        name: value
+        for name, value in vars(args).items()
+        if name in schema_fields and value is not None
+    }
 
-    # Handle keys that don't match
-    if args.verbose is not None:
-        overrides["verbosity_level"] = args.verbose
-    if args.pre_processor is not None:
-        overrides["pre_processors"] = args.pre_processor
-    if args.post_processor is not None:
-        overrides["post_processors"] = args.post_processor
-    if args.key is not None:
-        overrides["input_variables"] = dict(args.key)
+    # `--key` collects KEY=VALUE pairs that the schema wants as a mapping.
+    if "input_variables" in overrides:
+        overrides["input_variables"] = dict(args.input_variables)
 
     return overrides
 
@@ -228,19 +218,21 @@ def _key_value_pair(string: str) -> tuple[str, str]:
     return key, value
 
 
-def _parse_arguments() -> Namespace:
-    """Parse command-line arguments using argparse.
+def _build_parser() -> ArgumentParser:
+    """Build the command-line argument parser.
 
     This private helper function defines the expected command-line arguments
     for the application using `argparse`. It configures various options such
     as verbosity level, recipe sources (individual or list), log file location,
     pre/post-processors, report directory, maximum concurrency for tasks,
-    cache plugin details, and AutoPkg-specific preferences. The parsed arguments
-    are then returned as a `Namespace` object for easy access throughout the
-    application.
+    cache plugin details, and AutoPkg-specific preferences.
+
+    Arguments that correspond to a `ConfigSchema` field declare a `dest`
+    matching that field's name, which is how `_schema_overrides_from_cli`
+    finds them.
 
     Returns:
-        A `Namespace` object containing the parsed command-line arguments.
+        An `ArgumentParser` configured with every supported argument.
     """
     project_metadata = metadata("cloud-autopkg-runner")
 
@@ -261,6 +253,7 @@ def _parse_arguments() -> Namespace:
     general.add_argument(
         "-v",
         "--verbose",
+        dest="verbosity_level",
         action="count",
         help="Verbosity level. Can be specified multiple times. (-vvv)",
     )
@@ -312,6 +305,7 @@ def _parse_arguments() -> Namespace:
     recipes.add_argument(
         "-k",
         "--key",
+        dest="input_variables",
         metavar="KEY=VALUE",
         action="append",
         help=(
@@ -326,6 +320,8 @@ def _parse_arguments() -> Namespace:
     processors = parser.add_argument_group("Pre/Post Processors")
     processors.add_argument(
         "--pre-processor",
+        dest="pre_processors",
+        metavar="PRE_PROCESSOR",
         action="append",
         help=(
             "Specify a pre-processor to run before the main AutoPkg recipe. "
@@ -335,6 +331,8 @@ def _parse_arguments() -> Namespace:
     )
     processors.add_argument(
         "--post-processor",
+        dest="post_processors",
+        metavar="POST_PROCESSOR",
         action="append",
         help=(
             "Specify a post-processor to run after the main AutoPkg recipe. "
@@ -381,7 +379,16 @@ def _parse_arguments() -> Namespace:
         type=Path,
     )
 
-    return parser.parse_args()
+    return parser
+
+
+def _parse_arguments() -> Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        A `Namespace` object containing the parsed command-line arguments.
+    """
+    return _build_parser().parse_args()
 
 
 async def _process_recipe_list(

--- a/src/cloud_autopkg_runner/settings.py
+++ b/src/cloud_autopkg_runner/settings.py
@@ -77,6 +77,9 @@ class Settings:
         self._cache_plugin: str = "default"
         self._cache_file: str = "metadata_cache.json"
 
+        self._azure_account_url: str | None = None
+        self._cloud_container_name: str | None = None
+
         self._initialized = True
 
     def load(self, schema: ConfigSchema) -> None:
@@ -455,7 +458,14 @@ class Settings:
 
         Returns:
             The URL of the Azure Account.
+
+        Raises:
+            SettingsValidationError: If no Azure Account URL has been configured.
         """
+        if self._azure_account_url is None:
+            raise SettingsValidationError(
+                "azure_account_url", "Required by the azure cache plugin"
+            )
         return self._azure_account_url
 
     @azure_account_url.setter
@@ -473,7 +483,15 @@ class Settings:
 
         Returns:
             The name of the container.
+
+        Raises:
+            SettingsValidationError: If no container name has been configured.
         """
+        if self._cloud_container_name is None:
+            raise SettingsValidationError(
+                "cloud_container_name",
+                "Required by the azure, gcs, and s3 cache plugins",
+            )
         return self._cloud_container_name
 
     @cloud_container_name.setter

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -343,10 +343,9 @@ async def test_get_recipe_path_recipe_lookup_error(
         await _get_recipe_path("test_recipe", mock_autopkg_prefs)
 
 
-# `recipes` selects what the CLI orchestrator iterates rather than how a run
-# behaves. The config file sets it, `_generate_recipe_list` reads it from the
-# schema, and `--recipe`/`--recipe-list` cover the CLI, so it has neither a
-# matching argparse dest nor a Settings property.
+# `--recipe`/`--recipe-list` cover `recipes` on the CLI, and
+# `_generate_recipe_list` reads it from the schema, so it needs no dest and no
+# Settings property.
 _SCHEMA_ONLY_FIELDS = {"recipes"}
 
 

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -343,10 +343,7 @@ async def test_get_recipe_path_recipe_lookup_error(
         await _get_recipe_path("test_recipe", mock_autopkg_prefs)
 
 
-# `--recipe`/`--recipe-list` cover `recipes` on the CLI, and
-# `_generate_recipe_list` reads it from the schema, so it needs no dest and no
-# Settings property.
-_SCHEMA_ONLY_FIELDS = {"recipes"}
+_CONFIG_FILE_ONLY_FIELDS = {"recipes"}
 
 
 def test_every_schema_field_has_a_cli_argument() -> None:
@@ -354,7 +351,7 @@ def test_every_schema_field_has_a_cli_argument() -> None:
     schema_fields = {field.name for field in dataclasses.fields(ConfigSchema)}
     dests = {action.dest for action in _build_parser()._actions}
 
-    assert schema_fields - dests == _SCHEMA_ONLY_FIELDS
+    assert schema_fields - dests == _CONFIG_FILE_ONLY_FIELDS
 
 
 def test_every_schema_field_has_a_settings_property() -> None:
@@ -363,7 +360,7 @@ def test_every_schema_field_has_a_settings_property() -> None:
 
     missing = {
         name
-        for name in schema_fields - _SCHEMA_ONLY_FIELDS
+        for name in schema_fields - _CONFIG_FILE_ONLY_FIELDS
         if not isinstance(getattr(Settings, name, None), property)
     }
 

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -1,6 +1,7 @@
 """Unit tests for __main__.py."""
 
 import asyncio
+import dataclasses
 import json
 import os
 import plistlib
@@ -18,6 +19,7 @@ from cloud_autopkg_runner.__main__ import (
     EXIT_SUCCESS,
     STOP_WORKER,
     _async_main,
+    _build_parser,
     _create_recipe,
     _generate_recipe_list,
     _get_recipe_path,
@@ -61,14 +63,14 @@ def test_cli_overrides_schema(tmp_path: Path) -> None:
         max_concurrency=5,
         recipe_timeout=60,
         report_dir=tmp_path / "test_reports",
-        verbose=2,
-        pre_processor=["com.example.identifier/preProcessorName"],
-        post_processor=["com.example.identifier/postProcessorName"],
+        verbosity_level=2,
+        pre_processors=["com.example.identifier/preProcessorName"],
+        post_processors=["com.example.identifier/postProcessorName"],
         azure_account_url=None,
         cloud_container_name=None,
         autopkg_path=Path("/opt/homebrew/bin/autopkg"),
         autopkg_pref_file=None,
-        key=[("KEY1", "VALUE1"), ("KEY2", "VALUE2")],
+        input_variables=[("KEY1", "VALUE1"), ("KEY2", "VALUE2")],
     )
 
     overrides = _schema_overrides_from_cli(args)
@@ -197,18 +199,18 @@ def test_parse_arguments() -> None:
     with patch.object(sys, "argv", testargs):
         args = _parse_arguments()
 
-    assert args.verbose == 2
+    assert args.verbosity_level == 2
     assert args.recipe == ["Recipe1", "Recipe2"]
     assert args.recipe_list == Path("recipes.json")
     assert args.cache_file == "test_cache.json"
     assert args.log_file == Path("test_log.txt")
     assert args.log_format == "text"
-    assert args.post_processor == ["PostProcessor1"]
-    assert args.pre_processor == ["PreProcessor1"]
+    assert args.post_processors == ["PostProcessor1"]
+    assert args.pre_processors == ["PreProcessor1"]
     assert args.recipe_timeout == 60
     assert args.report_dir == Path("test_reports")
     assert args.max_concurrency == 15
-    assert args.key == [("KEY1", "VALUE1"), ("KEY2", "VALUE2")]
+    assert args.input_variables == [("KEY1", "VALUE1"), ("KEY2", "VALUE2")]
 
 
 def test_parse_arguments_diff_syntax() -> None:
@@ -234,18 +236,18 @@ def test_parse_arguments_diff_syntax() -> None:
     with patch.object(sys, "argv", testargs):
         args = _parse_arguments()
 
-    assert args.verbose == 2
+    assert args.verbosity_level == 2
     assert args.recipe == ["Recipe1", "Recipe2"]
     assert args.recipe_list == Path("recipes.json")
     assert args.cache_file == "test_cache.json"
     assert args.log_file == Path("test_log.txt")
     assert args.log_format == "text"
-    assert args.post_processor == ["PostProcessor1"]
-    assert args.pre_processor == ["PreProcessor1"]
+    assert args.post_processors == ["PostProcessor1"]
+    assert args.pre_processors == ["PreProcessor1"]
     assert args.recipe_timeout == 60
     assert args.report_dir == Path("test_reports")
     assert args.max_concurrency == 15
-    assert args.key == [("KEY1", "VALUE1"), ("KEY2", "VALUE2")]
+    assert args.input_variables == [("KEY1", "VALUE1"), ("KEY2", "VALUE2")]
 
 
 @pytest.mark.asyncio
@@ -339,6 +341,48 @@ async def test_get_recipe_path_recipe_lookup_error(
         pytest.raises(RecipeLookupError),
     ):
         await _get_recipe_path("test_recipe", mock_autopkg_prefs)
+
+
+# `recipes` selects what the CLI orchestrator iterates rather than how a run
+# behaves. The config file sets it, `_generate_recipe_list` reads it from the
+# schema, and `--recipe`/`--recipe-list` cover the CLI, so it has neither a
+# matching argparse dest nor a Settings property.
+_SCHEMA_ONLY_FIELDS = {"recipes"}
+
+
+def test_every_schema_field_has_a_cli_argument() -> None:
+    """Each schema field must be reachable from the command line."""
+    schema_fields = {field.name for field in dataclasses.fields(ConfigSchema)}
+    dests = {action.dest for action in _build_parser()._actions}
+
+    assert schema_fields - dests == _SCHEMA_ONLY_FIELDS
+
+
+def test_every_schema_field_has_a_settings_property() -> None:
+    """Each schema field must be settable on Settings, the library API."""
+    schema_fields = {field.name for field in dataclasses.fields(ConfigSchema)}
+
+    missing = {
+        name
+        for name in schema_fields - _SCHEMA_ONLY_FIELDS
+        if not isinstance(getattr(Settings, name, None), property)
+    }
+
+    assert missing == set()
+
+
+def test_cli_arguments_reach_the_schema() -> None:
+    """Every parsed argument is either a schema field or consumed elsewhere."""
+    schema_fields = {field.name for field in dataclasses.fields(ConfigSchema)}
+    dests = {action.dest for action in _build_parser()._actions}
+
+    assert dests - schema_fields == {
+        "config_file",
+        "help",
+        "recipe",
+        "recipe_list",
+        "version",
+    }
 
 
 def test_key_value_pair() -> None:
@@ -594,17 +638,17 @@ def _cli_namespace() -> Namespace:
         cache_plugin=None,
         cloud_container_name=None,
         config_file=None,
-        key=None,
+        input_variables=None,
         log_file=None,
         log_format=None,
         max_concurrency=None,
-        post_processor=None,
-        pre_processor=None,
+        post_processors=None,
+        pre_processors=None,
         recipe=None,
         recipe_list=None,
         recipe_timeout=None,
         report_dir=None,
-        verbose=None,
+        verbosity_level=None,
     )
 
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -49,6 +49,30 @@ def test_autopkg_path_setter() -> None:
     assert settings.autopkg_path == Path("~/.venv/bin/autopkg").expanduser()
 
 
+@pytest.mark.parametrize("setting_name", ["azure_account_url", "cloud_container_name"])
+def test_cloud_setting_unset_raises(setting_name: str) -> None:
+    """Reading a cloud setting that was never configured names the setting."""
+    settings = Settings()
+
+    with pytest.raises(SettingsValidationError, match=setting_name):
+        getattr(settings, setting_name)
+
+
+@pytest.mark.parametrize(
+    ("setting_name", "value"),
+    [
+        ("azure_account_url", "https://myaccount.blob.core.windows.net"),
+        ("cloud_container_name", "my-bucket"),
+    ],
+)
+def test_cloud_setting_returns_configured_value(setting_name: str, value: str) -> None:
+    """A configured cloud setting reads back as a plain string."""
+    settings = Settings()
+    setattr(settings, setting_name, value)
+
+    assert getattr(settings, setting_name) == value
+
+
 def test_cache_file_setter() -> None:
     """Test setting the cache_file attribute with a Path object."""
     settings = Settings()


### PR DESCRIPTION
:black_heart:

Refs #237. Fixes #228.

## The quiet failure (#237)

`_schema_overrides_from_cli` carried a hand-maintained tuple of field names. A name missing from it parsed fine on the command line and was then dropped, so the flag appeared to work and had no effect.

Arguments that map to a `ConfigSchema` field now declare a `dest` matching that field's name, and the overrides dict is built by filtering the parsed namespace against `dataclasses.fields(ConfigSchema)`. The tuple is gone.

Four arguments needed a `dest` to line up: `--verbose`, `--pre-processor`, `--post-processor` and `--key`. Flag spellings are untouched, and `--help` output is byte-identical to `main` (the two processor flags carry an explicit `metavar`, since argparse otherwise derives it from `dest`).

I did not generate the `add_argument` calls from the dataclass, as the issue floats. Those calls carry help text, `choices`, short flags, `action`, and group assignment; moving that into `field(metadata=...)` costs more than it saves, and a missing flag is already a loud failure rather than a quiet one. Three tests pin the agreement instead:

- every schema field has a CLI argument
- every schema field has a `Settings` property
- every argument is either a schema field or a documented CLI-only one (`--config-file`, `--recipe`, `--recipe-list`, `--version`, `--help`)

Verified they fail by adding a field to `ConfigSchema` and wiring nothing to it: the first two catch it.

`recipes` is exempt from the first two, with a comment saying why — it selects what the CLI orchestrator iterates rather than how a run behaves, so `--recipe`/`--recipe-list` cover the CLI and `_generate_recipe_list` reads it from the schema.

## AttributeError on cloud settings (#228)

`cloud_container_name` and `azure_account_url` had properties but no backing attributes, so `--cache-plugin s3` without a bucket name died with a bare `AttributeError` naming a private attribute.

Both are now initialized, and reading either unset raises `SettingsValidationError` naming the setting and the plugins that need it:

```
Invalid value for 'cloud_container_name': Required by the azure, gcs, and s3 cache plugins
```

The properties stay typed `-> str`, so nothing changes for code that configures them. The cloud backends read the value in `__init__`, which `get_cache_plugin()` calls before any recipe runs, so the error arrives before work starts rather than mid-run.

## Library consumers

The wiki documents direct assignment on `Settings` as the library API, so that surface was the constraint throughout. Nothing here moves it: the #237 work is confined to private CLI functions, and #228 keeps the declared property types. The `Settings`-property test now guarantees every config option stays reachable the documented way.

One documentation defect surfaced: the wiki showed `settings.recipes = [...]`, but `Settings` has no such property, so that assignment silently did nothing. Fixed in the wiki repo.
