### PR TITLE
Reject configuration fields with no matching setting

### DIFF
--- a/src/cloud_autopkg_runner/exceptions.py
+++ b/src/cloud_autopkg_runner/exceptions.py
@@ -318,6 +318,25 @@ class SettingsValidationError(AutoPkgRunnerError):
         super().__init__(f"Invalid value for '{field_name}': {validation_error}")
 
 
+class UnknownSettingError(AutoPkgRunnerError):
+    """Error class for handling configuration fields with no matching setting.
+
+    This error indicates that a configuration field was applied to `Settings`
+    without a property of the same name to receive it.
+    """
+
+    def __init__(self, field_name: str) -> None:
+        """Initializes UnknownSettingError with the unmatched field name.
+
+        Args:
+            field_name: The name of the unmatched configuration field.
+        """
+        super().__init__(
+            f"No Settings property named '{field_name}'. Configuration fields "
+            "must match a Settings property."
+        )
+
+
 # Shell Command
 class ShellCommandError(AutoPkgRunnerError):
     """Base error class for handling issues with shell commands.

--- a/src/cloud_autopkg_runner/settings.py
+++ b/src/cloud_autopkg_runner/settings.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 # Keep these specific to avoid circular imports
 from cloud_autopkg_runner.config_schema import ConfigSchema
-from cloud_autopkg_runner.exceptions import SettingsValidationError
+from cloud_autopkg_runner.exceptions import SettingsValidationError, UnknownSettingError
 
 
 class Settings:
@@ -90,8 +90,20 @@ class Settings:
 
         Args:
             schema: A validated configuration schema.
+
+        Raises:
+            UnknownSettingError: If a schema field has no property of the
+                same name on this class.
         """
         for field in dataclasses.fields(schema):
+            # `recipes` selects what the runner iterates rather than how a
+            # run behaves. `_generate_recipe_list` reads it off the schema,
+            # so there is no property here to receive it.
+            if field.name == "recipes":
+                continue
+
+            self._validate_setting_exists(field.name)
+
             schema_value = getattr(schema, field.name)
             if schema_value is not None:
                 setattr(self, field.name, schema_value)
@@ -412,6 +424,24 @@ class Settings:
         """
         if value < 0:
             raise SettingsValidationError(field_name, "Must not be negative")
+
+    @classmethod
+    def _validate_setting_exists(cls, field_name: str) -> None:
+        """Validates that a name corresponds to a setting on this class.
+
+        Every setting is a property, so assigning to it runs that property's
+        setter and the validation it performs. A name that is not a property
+        would become a plain instance attribute instead, bypassing that
+        validation.
+
+        Args:
+            field_name: The name of the setting to look for.
+
+        Raises:
+            UnknownSettingError: If this class defines no property by that name.
+        """
+        if not isinstance(getattr(cls, field_name, None), property):
+            raise UnknownSettingError(field_name)
 
     # Plugin Properties
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,11 +1,13 @@
 """Tests for the settings module."""
 
+from dataclasses import make_dataclass
 from pathlib import Path
+from typing import cast
 
 import pytest
 
-from cloud_autopkg_runner import Settings
-from cloud_autopkg_runner.exceptions import SettingsValidationError
+from cloud_autopkg_runner import ConfigSchema, Settings
+from cloud_autopkg_runner.exceptions import SettingsValidationError, UnknownSettingError
 
 
 def test_singleton_pattern() -> None:
@@ -271,3 +273,69 @@ def test_input_variables_setter(
     settings = Settings()
     settings.input_variables = input_value
     assert settings.input_variables == expected_output
+
+
+def test_load_applies_schema_values() -> None:
+    """Schema values reach the properties, running their setters."""
+    settings = Settings()
+    settings.load(
+        ConfigSchema(
+            log_format="json",
+            max_concurrency=4,
+            report_dir=Path("custom_reports"),
+            pre_processors="com.example/OnlyOne",
+            cache_plugin="s3",
+        )
+    )
+
+    assert settings.log_format == "json"
+    assert settings.max_concurrency == 4
+    assert settings.report_dir == Path("custom_reports")
+    assert settings.cache_plugin == "s3"
+
+    # The setter wraps a lone processor in a list.
+    assert settings.pre_processors == ["com.example/OnlyOne"]
+
+
+def test_load_leaves_defaults_for_unset_values() -> None:
+    """An empty schema changes nothing, since every field is None."""
+    settings = Settings()
+    settings.load(ConfigSchema())
+
+    assert settings.log_format == "text"
+    assert settings.max_concurrency == 10
+    assert settings.recipe_timeout == 300
+    assert settings.report_dir == Path("recipe_reports")
+    assert settings.verbosity_level == 0
+
+
+def test_load_skips_config_file_only_fields() -> None:
+    """`recipes` is read from the schema and never lands on Settings."""
+    settings = Settings()
+    settings.load(ConfigSchema(recipes=["Foo.recipe"]))
+
+    assert not hasattr(settings, "recipes")
+
+
+def test_load_raises_for_field_without_a_property() -> None:
+    """A schema field with no matching property is an error, not an attribute."""
+    schema = make_dataclass("FakeSchema", [("nonexistent_setting", "str | None")])(
+        nonexistent_setting="value"
+    )
+    settings = Settings()
+
+    with pytest.raises(UnknownSettingError, match="nonexistent_setting"):
+        settings.load(cast("ConfigSchema", schema))
+
+    assert not hasattr(settings, "nonexistent_setting")
+
+
+def test_load_raises_even_when_the_value_is_unset() -> None:
+    """The name is checked whether or not the field carries a value."""
+    schema = make_dataclass("FakeSchema", [("nonexistent_setting", "str | None")])(
+        nonexistent_setting=None
+    )
+    settings = Settings()
+
+    with pytest.raises(UnknownSettingError, match="nonexistent_setting"):
+        settings.load(cast("ConfigSchema", schema))


### PR DESCRIPTION
:black_heart:

Fixes #229

## Problem

`Settings.load()` copied every non-`None` `ConfigSchema` field on by name. A name that matched a property ran its setter and the validation that setter performs; a name that did not became a plain instance attribute, so the value was accepted and every validator skipped without any signal.

`ConfigSchema.recipes` already took that path. It was harmless because `_generate_recipe_list` reads `schema.recipes` rather than going through `Settings`, but the same mechanism meant a mistyped property name would bypass the whole class silently.

## Change

`load()` now checks each field name against the class before assigning it, and raises a new `UnknownSettingError` when no property answers to that name. The check runs whether or not the field carries a value, so a mismatch surfaces even when the option is unset.

`recipes` is skipped by name, with a comment saying why. Adding another property-less schema field would both raise here and fail `test_every_schema_field_has_a_settings_property`, so the decision stays where it belongs rather than being absorbed by a mechanism.

The lookup goes through the class rather than the instance: reading `azure_account_url` or `cloud_container_name` off an instance raises from their getters when unconfigured.

## Compatibility

No user-visible change on either entry point. `ConfigSchema.from_dict` already rejects unknown config keys, so a schema can only carry declared fields, and every one but `recipes` has a property — the new error fires only on a mistake made in this repo. The documented library usage assigns properties directly (`settings.cache_plugin = "s3"`) and never calls `load()`.

One behavior change worth naming: `Settings().recipes` no longer springs into existence after loading a schema that carries recipes. That attribute was an accident of the old `setattr` — it is not a property, not in the wiki's settings list, and nothing in `src/`, `tests/`, the wiki, or the examples repo reads it.

`UnknownSettingError` subclasses `AutoPkgRunnerError`, so existing handlers keep working.

## Tests

`Settings.load()` had no coverage at all. Five cases added in `tests/unit/test_settings.py`: values reaching their setters, defaults surviving an empty schema, `recipes` staying off the instance, and the new error raising both with and without a value present.

Verified end to end as well — a `config.toml` carrying `recipes` plus real settings still applies correctly and still drives the run list, and injecting a misspelled `max_concurency` field into `ConfigSchema` makes the CLI fail with `No Settings property named 'max_concurency'` instead of starting up.